### PR TITLE
Fix Bulgarian split squat processing flow and early-exit logic

### DIFF
--- a/bulgarian_split_squat_analysis.py
+++ b/bulgarian_split_squat_analysis.py
@@ -475,16 +475,16 @@ def run_bulgarian_analysis(video_path, frame_skip=1, scale=1.0,
 
     fps_in = cap.get(cv2.CAP_PROP_FPS) or 25
     effective_fps = max(1.0, fps_in / max(1, frame_skip))
-dt = 1.0 / float(effective_fps)
+    dt = 1.0 / float(effective_fps)
 
-# === EXIT CONDITIONS (כמו בפול-אפ) ===
-NOPOSE_STOP_SEC = 1.2
-NOPOSE_STOP_FRAMES = int(NOPOSE_STOP_SEC * effective_fps)
-nopose_frames_since_any_rep = 0
+    # === EXIT CONDITIONS (כמו בפול-אפ) ===
+    NOPOSE_STOP_SEC = 1.2
+    NOPOSE_STOP_FRAMES = int(NOPOSE_STOP_SEC * effective_fps)
+    nopose_frames_since_any_rep = 0
 
-NO_MOVEMENT_STOP_SEC = 1.3
-NO_MOVEMENT_STOP_FRAMES = int(NO_MOVEMENT_STOP_SEC * effective_fps)
-no_movement_frames = 0
+    NO_MOVEMENT_STOP_SEC = 1.3
+    NO_MOVEMENT_STOP_FRAMES = int(NO_MOVEMENT_STOP_SEC * effective_fps)
+    no_movement_frames = 0
 
 
     # עומק "לייב" דו-כיווני (גם בירידה וגם בעלייה)
@@ -521,21 +521,22 @@ no_movement_frames = 0
         depth_live = 0.0
 
         if not results.pose_landmarks:
-    if counter.count > 0:
-        nopose_frames_since_any_rep += 1
-    else:
-        nopose_frames_since_any_rep = 0
+            if counter.count > 0:
+                nopose_frames_since_any_rep += 1
+            else:
+                nopose_frames_since_any_rep = 0
 
-    if counter.count > 0 and nopose_frames_since_any_rep >= NOPOSE_STOP_FRAMES:
-        break
+            if counter.count > 0 and nopose_frames_since_any_rep >= NOPOSE_STOP_FRAMES:
+                break
 
-    if rt_fb_hold > 0:
-        rt_fb_hold -= 1
+            if rt_fb_hold > 0:
+                rt_fb_hold -= 1
+            no_movement_frames = 0
 
-    stab_lms = lm_stab.stabilize(None)
-else:
-    nopose_frames_since_any_rep = 0
-    lms = results.pose_landmarks.landmark
+            stab_lms = lm_stab.stabilize(None)
+        else:
+            nopose_frames_since_any_rep = 0
+            lms = results.pose_landmarks.landmark
             if active_leg is None:
                 active_leg = detect_active_leg(lms)
             side = "RIGHT" if active_leg == "right" else "LEFT"
@@ -556,17 +557,15 @@ else:
             ankle_vel_ema = MOTION_EMA_ALPHA*an_vel  + (1-MOTION_EMA_ALPHA)*ankle_vel_ema
             prev_hip, prev_la, prev_ra = hip_px, l_ankle_px, r_ankle_px
             movement_block = (hip_vel_ema > HIP_VEL_THRESH_PCT) or (ankle_vel_ema > ANKLE_VEL_THRESH_PCT)
-            if movement_block: movement_free_streak = 0
-            else:              movement_free_streak = min(MOVEMENT_CLEAR_FRAMES, movement_free_streak + 1)
-                ifif movement_block:
-    movement_free_streak = 0
-    no_movement_frames = 0
-else:
-    movement_free_streak = min(MOVEMENT_CLEAR_FRAMES, movement_free_streak + 1)
-    no_movement_frames += 1
+            if movement_block:
+                movement_free_streak = 0
+                no_movement_frames = 0
+            else:
+                movement_free_streak = min(MOVEMENT_CLEAR_FRAMES, movement_free_streak + 1)
+                no_movement_frames += 1
 
-if counter.count > 0 and no_movement_frames >= NO_MOVEMENT_STOP_FRAMES:
-    break
+            if counter.count > 0 and no_movement_frames >= NO_MOVEMENT_STOP_FRAMES:
+                break
 
 
 


### PR DESCRIPTION
### Motivation
- The Bulgarian split squat analyzer could produce a gray/stalled output because parts of the processing loop were mis-indented and contained stray/corrupted conditional blocks. 
- The goal is to restore correct early-exit behavior and skeleton stabilization so overlays and rep counting behave like the other analyzers.

### Description
- Fixed indentation and scoping in `run_bulgarian_analysis` so `dt`, `NOPOSE_*` and `NO_MOVEMENT_*` are defined inside the function and computed from `effective_fps`.
- Restored the `if not results.pose_landmarks` branch to correctly update `nopose_frames_since_any_rep`, decrement `rt_fb_hold`, reset `no_movement_frames`, and call `lm_stab.stabilize(None)`.
- Repaired movement handling by fixing `movement_block` handling: set `no_movement_frames = 0` when movement is detected, otherwise increment it; added the early-exit check using `NO_MOVEMENT_STOP_FRAMES`.
- Removed stray corrupted conditionals and re-aligned the pose-processing branch so `stab_lms = lm_stab.stabilize(lms)` and drawing/overlay logic run reliably in all cases in `bulgarian_split_squat_analysis.py`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b8c495e4c8323abc9f8f5eabca132)