### PR TITLE
Add dips analyzer routing

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ EXERCISE_MAP = {
     "barbell bent over row": "bent_row", "bent over row": "bent_row",
     "barbell row": "bent_row", "row": "bent_row",
     "good morning": "good_morning", "good mornings": "good_morning", "good morningg": "good_morning",
+    "dips": "dips", "dip": "dips",
 }
 
 # -------- Error handling & logging --------
@@ -125,6 +126,7 @@ run_pullup      = load_func_soft('pullup_analysis', 'run_pullup_analysis', 'run_
 run_bicep_curl  = load_func_soft('barbell_bicep_curl', 'run_barbell_bicep_curl_analysis', 'run_analysis')
 run_bent_row    = load_func_soft('bent_over_row_analysis', 'run_row_analysis', 'run_analysis')
 run_good_morning = load_func_soft('good_morning_analysis', 'run_good_morning_analysis', 'run_analysis')
+run_dips        = load_func_soft('dips_analysis', 'run_dips_analysis', 'run_analysis')
 
 # -------- Streaming saves --------
 def _save_upload_streaming(file_storage, dest_path, chunk_size=8*1024*1024):
@@ -159,6 +161,8 @@ def _do_analyze(resolved_type, raw_video_path, analyzed_path, fast_flag: bool):
         return _standardize_video_path(result)
     elif resolved_type == 'good_morning':
         return _run_with_tracks(run_good_morning, raw_video_path, analyzed_path, fast_flag, frame_skip=3, scale=0.4)
+    elif resolved_type == 'dips':
+        return _run_with_tracks(run_dips, raw_video_path, analyzed_path, fast_flag, frame_skip=3, scale=0.4)
     else:
         return {"error": f"Unhandled exercise type: {resolved_type}", "video_path": ""}
 


### PR DESCRIPTION
### Motivation
- Enable the unified `/analyze` API to dispatch to the dips analyzer so uploaded dips videos are processed like other exercises.

### Description
- Add `"dips"`/`"dip"` aliases to `EXERCISE_MAP` in `app.py`.
- Register `run_dips = load_func_soft('dips_analysis', 'run_dips_analysis', 'run_analysis')` so the module is resolved safely.
- Add a `resolved_type == 'dips'` branch in `_do_analyze` to call `_run_with_tracks(run_dips, ...)` with the same defaults as other analyzers.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b8f2b61508323b9744d6e58c2fcb6)