### PR TITLE
Add 'Great form' feedback for perfect dips

### DIFF
--- a/dips_analysis.py
+++ b/dips_analysis.py
@@ -557,6 +557,8 @@ def run_dips_analysis(video_path,
     # Build feedback
     all_fb = set(session_feedback) if session_feedback else set()
     fb_list = [cue for cue in FORM_TIP_PRIORITY if cue in all_fb]
+    if not fb_list and technique_score >= 10.0 - 1e-6:
+        fb_list = ["Great form! Keep it up 💪"]
 
     form_tip = None
     if all_fb:


### PR DESCRIPTION
### Motivation
- Align dips feedback with other exercise analyses by returning a positive default message when a dips session has a perfect technique score and no form issues.

### Description
- In `dips_analysis.py` add a post-score check that sets `fb_list = ["Great form! Keep it up 💪"]` when `fb_list` is empty and `technique_score >= 10.0 - 1e-6`, leaving the existing feedback file writing logic unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c8e170e308323af7a507b237aa3e7)