### PR TITLE
Compute pull-up technique score from per-rep average with penalty fallback

### DIFF
--- a/pullup_analysis.py
+++ b/pullup_analysis.py
@@ -600,7 +600,10 @@ def run_pullup_analysis(video_path,
     cv2.destroyAllWindows()
 
     # ===== Session Technique Score =====
-    if rep_count==0: technique_score=0.0
+    if rep_count==0:
+        technique_score=0.0
+    elif all_scores:
+        technique_score=_half_floor10(np.mean(all_scores))
     else:
         if session_feedback:
             penalty = sum(FB_WEIGHTS.get(m,FB_DEFAULT_WEIGHT) for m in set(session_feedback))


### PR DESCRIPTION
### Motivation
- Make the reported pull-up `Technique Score` reflect the actual per-rep scores when those are present so a session with the vast majority of good reps (e.g. 26/27) yields a high score (e.g. 9.5) instead of being overly reduced by session-level penalties.

### Description
- Update `pullup_analysis.py` so that when `all_scores` exists the session `technique_score` is set to `_half_floor10(np.mean(all_scores))`, while preserving the existing penalty-based fallback that sums `FB_WEIGHTS` from `session_feedback` and the `rep_count==0` -> `0.0` case.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c9cc2b1a0832391eac2978dde8e75)