### PR TITLE
Unify pull-up track and separate form tip messages

### DIFF
--- a/app.py
+++ b/app.py
@@ -163,7 +163,7 @@ def _do_analyze(resolved_type, raw_video_path, analyzed_path, fast_flag: bool):
     elif resolved_type == 'bulgarian':
         return _run_with_tracks(run_bulgarian, raw_video_path, analyzed_path, fast_flag, frame_skip=3, scale=0.4)
     elif resolved_type == 'pullup':
-        return _run_with_tracks(run_pullup, raw_video_path, analyzed_path, fast_flag, frame_skip=3, scale=0.4)
+        return _run_with_tracks(run_pullup, raw_video_path, analyzed_path, False, frame_skip=3, scale=0.4)
     elif resolved_type == 'bicep_curl':
         return _run_with_tracks(run_bicep_curl, raw_video_path, analyzed_path, fast_flag, frame_skip=3, scale=0.4)
     elif resolved_type == 'bent_row':


### PR DESCRIPTION
### Motivation
- Treat `form_tip` as a distinct short guidance message separate from the full feedback cue list, and experiment with a single pull-up processing path that always returns a video and does not use the fast/slow branching.

### Description
- Add `FORM_TIP_MESSAGES` and map the selected feedback key to a short human-facing guidance string for `form_tip` instead of returning the cue text itself.
- Force the pull-up analyzer to use the full model and always return video by setting `model_complexity = 1` and `return_video = True` in `run_pullup_analysis`.
- Make the API ignore the `fast` flag for pull-ups by passing `False` to `_run_with_tracks` for the `pullup` branch in `app.py` so only the single video-returning path is used.
- Update the file header/comment to clarify that `form_tip` is a separate short guidance message.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c9cc2b1a0832391eac2978dde8e75)