### PR TITLE
Restore pullup 'Great form' fallback and per-rep scoring; add form-tip messages

### DIFF
--- a/app.py
+++ b/app.py
@@ -163,7 +163,7 @@ def _do_analyze(resolved_type, raw_video_path, analyzed_path, fast_flag: bool):
     elif resolved_type == 'bulgarian':
         return _run_with_tracks(run_bulgarian, raw_video_path, analyzed_path, fast_flag, frame_skip=3, scale=0.4)
     elif resolved_type == 'pullup':
-        return _run_with_tracks(run_pullup, raw_video_path, analyzed_path, fast_flag, frame_skip=3, scale=0.4)
+        return _run_with_tracks(run_pullup, raw_video_path, analyzed_path, False, frame_skip=3, scale=0.4)
     elif resolved_type == 'bicep_curl':
         return _run_with_tracks(run_bicep_curl, raw_video_path, analyzed_path, fast_flag, frame_skip=3, scale=0.4)
     elif resolved_type == 'bent_row':

--- a/pullup_analysis.py
+++ b/pullup_analysis.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # pullup_analysis.py — original rep counting kept (27/27) + burst & robust feedback
-# feedback = all cues; form_tip = single prioritized cue (omitted if none)
+# feedback = all cues; form_tip = separate short guidance message (omitted if none)
 
 import os, cv2, math, numpy as np, subprocess
 from collections import deque
@@ -165,6 +165,11 @@ PENALTY_MIN_IF_ANY=0.5
 
 # סדר עדיפויות ל-form_tip
 FORM_TIP_PRIORITY = [FB_CUE_HIGHER, FB_CUE_BOTTOM, FB_CUE_SWING]
+FORM_TIP_MESSAGES = {
+    FB_CUE_HIGHER: "Aim to clear the bar with your chin every rep",
+    FB_CUE_BOTTOM: "Reset to a full hang before pulling again",
+    FB_CUE_SWING: "Keep a steady body line throughout the pull",
+}
 
 # ============ Swing / Bottom heuristics ============
 SWING_THR=0.012; SWING_MIN_STREAK=3
@@ -206,10 +211,8 @@ def run_pullup_analysis(video_path,
     if mp_pose is None:
         return _ret_err("Mediapipe not available", feedback_path)
 
-    model_complexity = 0 if fast_mode else 1
-    if fast_mode:
-        return_video = False
-        scale = min(scale, 0.35)
+    model_complexity = 1
+    return_video = True
 
     if preserve_quality:
         scale=1.0; frame_skip=1; encode_crf=18 if encode_crf is None else encode_crf
@@ -600,7 +603,10 @@ def run_pullup_analysis(video_path,
     cv2.destroyAllWindows()
 
     # ===== Session Technique Score =====
-    if rep_count==0: technique_score=0.0
+    if rep_count==0:
+        technique_score=0.0
+    elif all_scores:
+        technique_score=_half_floor10(np.mean(all_scores))
     else:
         if session_feedback:
             penalty = sum(FB_WEIGHTS.get(m,FB_DEFAULT_WEIGHT) for m in set(session_feedback))
@@ -613,13 +619,16 @@ def run_pullup_analysis(video_path,
     all_fb = set(session_feedback) if session_feedback else set()
     FEEDBACK_ORDER = FORM_TIP_PRIORITY
     fb_list = [cue for cue in FEEDBACK_ORDER if cue in all_fb]  # ordered, unique
+    if not fb_list and rep_count > 0 and bad_reps == 0:
+        fb_list = ["Great form! Keep it up 💪"]
 
     form_tip = None
     if all_fb:
-        form_tip = max(all_fb, key=lambda m: (FB_WEIGHTS.get(m, FB_DEFAULT_WEIGHT),
-                                              -FEEDBACK_ORDER.index(m) if m in FEEDBACK_ORDER else -999))
+        form_tip_key = max(all_fb, key=lambda m: (FB_WEIGHTS.get(m, FB_DEFAULT_WEIGHT),
+                                                  -FEEDBACK_ORDER.index(m) if m in FEEDBACK_ORDER else -999))
+        form_tip = FORM_TIP_MESSAGES.get(form_tip_key, "Focus on smooth, controlled reps")
 
-    # Write file (no "Great form")
+    # Write file
     try:
         with open(feedback_path,"w",encoding="utf-8") as f:
             f.write(f"Total Reps: {int(rep_count)}\n")


### PR DESCRIPTION
### Motivation
- Restore prior pull-up behavior so a positive summary message appears when there are reps and no detected issues, and ensure technique scoring reflects per-rep measurements instead of always returning a perfect score after a previous change.
- Keep the single pull-up processing path that ignores the `fast` flag to ensure consistent analyzer behavior.

### Description
- Add a `FORM_TIP_MESSAGES` mapping and use `form_tip_key` with `FORM_TIP_MESSAGES.get(...)` to produce a short human-facing `form_tip` instead of raw cue text.
- Reintroduce a positive fallback by appending `"Great form! Keep it up 💪"` to `fb_list` when `rep_count > 0` and `bad_reps == 0` via `if not fb_list and rep_count > 0 and bad_reps == 0: fb_list = ["Great form! Keep it up 💪"]`.
- Adjust session technique scoring so that when per-rep scores exist `technique_score` is `_half_floor10(np.mean(all_scores))`, otherwise fall back to the previous penalty-based calculation.
- Ensure the API always runs the pull-up analyzer on the full path by calling `_run_with_tracks(run_pullup, ..., False, ...)` to ignore the `fast` flag in `app.py`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c9cc2b1a0832391eac2978dde8e75)