### PR TITLE
Deduplicate Romanian deadlift feedback

### DIFF
--- a/romanian_deadlift_analysis.py
+++ b/romanian_deadlift_analysis.py
@@ -81,6 +81,16 @@ def merge_feedback(global_best, new_list):
         return cand
     return cand if FB_SEVERITY.get(cand,1) >= FB_SEVERITY.get(global_best,1) else global_best
 
+def dedupe_feedback(feedback_list):
+    seen = set()
+    unique = []
+    for fb in feedback_list or []:
+        if fb in seen:
+            continue
+        seen.add(fb)
+        unique.append(fb)
+    return unique
+
 # ===================== SCORE DISPLAY =====================
 def score_label(s):
     s = float(s)
@@ -419,7 +429,7 @@ def run_romanian_deadlift_analysis(video_path,
     if session_feedbacks and len(session_feedbacks) > 0:
         technique_score = min(technique_score, 9.5)
 
-    feedback_list = session_feedbacks if session_feedbacks else ["Great form! Keep it up 💪"]
+    feedback_list = dedupe_feedback(session_feedbacks) if session_feedbacks else ["Great form! Keep it up 💪"]
 
     session_tip = None
     if session_feedback_by_cat:


### PR DESCRIPTION
### Motivation
- Prevent repeated feedback messages from appearing multiple times in the final session feedback for the Romanian deadlift analyzer.

### Description
- Add a helper `dedupe_feedback(feedback_list)` that preserves the first occurrence of each feedback string and removes duplicates.
- Apply `dedupe_feedback` to `session_feedbacks` before writing the feedback file and returning the result, so the `feedback` field contains unique messages.
- Change is contained to `romanian_deadlift_analysis.py` and preserves existing scoring and per-rep logic while only deduplicating the final session-level feedback list.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982333d9c488323bfb5e0af5396c6d9)