### PR TITLE
Use Dockerfile-based Fly build

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -2,7 +2,7 @@ app = "squat-api-docker"
 primary_region = "fra"
 
 [build]
-  builder = "paketobuildpacks/builder:base"
+  dockerfile = "Dockerfile"
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
### Motivation
- The Fly deployment was using the buildpack builder which triggered the `/cnb/process/web` early-exit behavior in logs, so switching to the repository `Dockerfile` ensures the container is built and run via the intended image (which runs `python app.py`).

### Description
- Replace the `[build]` buildpack configuration in `fly.toml` with `dockerfile = "Dockerfile"` so Fly uses the repo Dockerfile for builds.

### Testing
- No automated tests were run because this is a configuration-only change and the `fly.toml` file was validated by inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69833d93d4448323afca6850d198e1fe)