### PR TITLE
Fix Dockerfile ENV syntax; harden pip installs and use Dockerfile for Fly builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,17 @@ RUN python -m pip install --upgrade pip setuptools wheel
 
 # הגדרות להתמודדות עם בעיות רשת PyPI
 ENV PIP_DEFAULT_TIMEOUT=100
-ENV PIP_RETRIES=10
+ENV PIP_RETRIES=20
+ENV PIP_INDEX_URL=https://pypi.org/simple
+ENV PIP_TRUSTED_HOST="pypi.org files.pythonhosted.org"
 
 # התקנת דרישות
 COPY requirements.txt requirements.txt
-RUN pip install --no-cache-dir --timeout 100 --retries 10 -r requirements.txt
+RUN pip install --no-cache-dir --timeout 100 --retries 20 \
+    --index-url https://pypi.org/simple \
+    --trusted-host pypi.org \
+    --trusted-host files.pythonhosted.org \
+    -r requirements.txt
 
 # קוד האפליקציה
 COPY . .

--- a/fly.toml
+++ b/fly.toml
@@ -2,7 +2,7 @@ app = "squat-api-docker"
 primary_region = "fra"
 
 [build]
-  builder = "paketobuildpacks/builder:base"
+  dockerfile = "Dockerfile"
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
### Motivation
- Make Python package installation more resilient to transient PyPI/network issues by increasing retry/timeouts and pinning the index/trusted hosts.
- Resolve a Dockerfile parse failure caused by an unquoted multi-value `ENV` which broke `flyctl deploy` with a syntax error.
- Use an explicit Dockerfile for Fly builds instead of the previous buildpack builder.

### Description
- Updated `Dockerfile` to set `PIP_RETRIES=20`, `PIP_INDEX_URL=https://pypi.org/simple`, and `PIP_TRUSTED_HOST` with a quoted multi-value string to satisfy Docker `ENV` syntax.
- Modified the `pip install` invocation in the `Dockerfile` to use `--index-url https://pypi.org/simple`, `--trusted-host pypi.org`, `--trusted-host files.pythonhosted.org`, and `--retries 20`.
- Fixed the Dockerfile parse error by quoting the `PIP_TRUSTED_HOST` value (`"pypi.org files.pythonhosted.org"`).
- Updated `fly.toml` to use `dockerfile = "Dockerfile"` for builds and removed the previous `builder` setting.

### Testing
- A `flyctl deploy --build-only --push ...` run previously failed with: `Syntax error - can't find = in "files.pythonhosted.org"`; this motivated the quoting fix.
- After the change the `Dockerfile` was inspected (`nl -ba Dockerfile`) and committed, but a full `flyctl` build/push was not re-run in this rollout.
- No automated unit tests were executed because these are Docker build configuration changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69833d93d4448323afca6850d198e1fe)