### PR TITLE
Add PyPI mirror fallback and refine pip BuildKit settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.5
 # Python בסיסי, ללא CUDA/GPU
 FROM python:3.10-slim
 
@@ -16,15 +17,27 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 WORKDIR /app
 
 # רצוי לשדרג pip וכלי build
-RUN python -m pip install --upgrade pip setuptools wheel
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python -m pip install --upgrade pip setuptools wheel
 
 # הגדרות להתמודדות עם בעיות רשת PyPI
-ENV PIP_DEFAULT_TIMEOUT=100
-ENV PIP_RETRIES=10
+ENV PIP_DEFAULT_TIMEOUT=30
+ENV PIP_RETRIES=5
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PIP_PROGRESS_BAR=off
+ENV PIP_INDEX_URL=https://pypi.org/simple
+ENV PIP_EXTRA_INDEX_URL=https://pypi.python.org/simple
+ENV PIP_TRUSTED_HOST="pypi.org files.pythonhosted.org"
 
 # התקנת דרישות
 COPY requirements.txt requirements.txt
-RUN pip install --no-cache-dir --timeout 100 --retries 10 -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir --timeout 30 --retries 5 --prefer-binary \
+    --index-url https://pypi.org/simple \
+    --extra-index-url https://pypi.python.org/simple \
+    --trusted-host pypi.org \
+    --trusted-host files.pythonhosted.org \
+    -r requirements.txt
 
 # קוד האפליקציה
 COPY . .

--- a/fly.toml
+++ b/fly.toml
@@ -2,7 +2,7 @@ app = "squat-api-docker"
 primary_region = "fra"
 
 [build]
-  builder = "paketobuildpacks/builder:base"
+  dockerfile = "Dockerfile"
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
### Motivation
- Address intermittent PyPI connection resets observed during Docker builds that caused `pip install` to fail. 
- Make pip installs more robust and faster by enabling BuildKit cache mounts for pip and by tuning pip network/UX settings. 
- Ensure the build uses the repository `Dockerfile` configuration rather than the buildpack builder.

### Description
- Add a fallback PyPI index via `ENV PIP_EXTRA_INDEX_URL=https://pypi.python.org/simple` and pass `--extra-index-url` to `pip install` so pip can retry against an alternate mirror. 
- Enable BuildKit cache mounts for pip on both the pip upgrade step and the requirements install step with `--mount=type=cache,target=/root/.cache/pip`. 
- Lower pip timeouts/retries and disable noisy output by setting `ENV PIP_DEFAULT_TIMEOUT=30`, `ENV PIP_RETRIES=5`, `ENV PIP_DISABLE_PIP_VERSION_CHECK=1`, and `ENV PIP_PROGRESS_BAR=off`. 
- Make `pip install` call more explicit with `--index-url`, `--extra-index-url`, `--trusted-host` flags and `--prefer-binary` to improve reliability. 
- Switch `fly.toml` build configuration to point to the `Dockerfile` (`[build].dockerfile = "Dockerfile"`) instead of the previous buildpack builder.

### Testing
- No automated tests were run for this change (Docker build configuration changes only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69833d93d4448323afca6850d198e1fe)