### PR TITLE
Add alternate PyPI mirror (Tsinghua) and pip build refinements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.5
 # Python בסיסי, ללא CUDA/GPU
 FROM python:3.10-slim
 
@@ -16,15 +17,29 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 WORKDIR /app
 
 # רצוי לשדרג pip וכלי build
-RUN python -m pip install --upgrade pip setuptools wheel
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python -m pip install --upgrade pip setuptools wheel
 
 # הגדרות להתמודדות עם בעיות רשת PyPI
-ENV PIP_DEFAULT_TIMEOUT=100
-ENV PIP_RETRIES=10
+ENV PIP_DEFAULT_TIMEOUT=30
+ENV PIP_RETRIES=5
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PIP_PROGRESS_BAR=off
+ENV PIP_INDEX_URL=https://pypi.org/simple
+ENV PIP_EXTRA_INDEX_URL="https://pypi.python.org/simple https://pypi.tuna.tsinghua.edu.cn/simple"
+ENV PIP_TRUSTED_HOST="pypi.org files.pythonhosted.org pypi.tuna.tsinghua.edu.cn"
 
 # התקנת דרישות
 COPY requirements.txt requirements.txt
-RUN pip install --no-cache-dir --timeout 100 --retries 10 -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir --timeout 30 --retries 5 --prefer-binary \
+    --index-url https://pypi.org/simple \
+    --extra-index-url https://pypi.python.org/simple \
+    --extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple \
+    --trusted-host pypi.org \
+    --trusted-host files.pythonhosted.org \
+    --trusted-host pypi.tuna.tsinghua.edu.cn \
+    -r requirements.txt
 
 # קוד האפליקציה
 COPY . .

--- a/fly.toml
+++ b/fly.toml
@@ -2,7 +2,7 @@ app = "squat-api-docker"
 primary_region = "fra"
 
 [build]
-  builder = "paketobuildpacks/builder:base"
+  dockerfile = "Dockerfile"
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
### Motivation
- The Docker image build was failing due to intermittent PyPI connection resets during `pip install`, which caused errors like `No matching distribution found for Flask` in the `flyctl deploy` build logs. 
- Improve build reliability and performance by adding an alternate PyPI mirror, tuning pip runtime/UX environment variables, and ensuring BuildKit cache mounts are used for pip.

### Description
- Add Tsinghua PyPI mirror to `PIP_EXTRA_INDEX_URL` and include it in `PIP_TRUSTED_HOST` in the `Dockerfile` so pip can fall back to an alternate index. 
- Pass `--extra-index-url` and `--trusted-host` flags for the Tsinghua mirror to the `pip install -r requirements.txt` invocation and keep `--index-url` pointed at `https://pypi.org/simple`.
- Enable BuildKit cache mounts for pip on both the pip upgrade step and the requirements install step using `--mount=type=cache,target=/root/.cache/pip` and set pip environment variables `PIP_DEFAULT_TIMEOUT=30`, `PIP_RETRIES=5`, `PIP_DISABLE_PIP_VERSION_CHECK=1`, and `PIP_PROGRESS_BAR=off` to reduce noise and shorten timeouts.
- Update `fly.toml` build config to use the repository `Dockerfile` via `[build].dockerfile = "Dockerfile"`.

### Testing
- No automated tests were run for this change (Docker build configuration change only). 
- An earlier automated build triggered by `flyctl deploy --build-only` failed before this change due to repeated connection resets when fetching packages from PyPI. 
- No subsequent automated build was executed after adding the alternate mirror in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69833d93d4448323afca6850d198e1fe)