### PR TITLE
Add fast/slow (no-video/video) toggles to analyzers

### DIFF
--- a/barbell_bicep_curl.py
+++ b/barbell_bicep_curl.py
@@ -223,7 +223,12 @@ def run_barbell_bicep_curl_analysis(video_path,
                                     frame_skip=3,     # זהה לסקוואט
                                     scale=0.4,        # זהה לסקוואט
                                     output_path="barbell_curl_analyzed.mp4",
-                                    feedback_path="barbell_curl_feedback.txt"):
+                                    feedback_path="barbell_curl_feedback.txt",
+                                    return_video=True,
+                                    fast_mode=None):
+    if fast_mode is True:
+        return_video = False
+
     cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
         return {
@@ -284,7 +289,7 @@ def run_barbell_bicep_curl_analysis(video_path,
             if scale != 1.0: frame = cv2.resize(frame, (0,0), fx=scale, fy=scale)
 
             h, w = frame.shape[:2]
-            if out is None:
+            if return_video and out is None:
                 out = cv2.VideoWriter(output_path, fourcc, effective_fps, (w, h))
 
             image = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
@@ -294,8 +299,11 @@ def run_barbell_bicep_curl_analysis(video_path,
             if not results.pose_landmarks:
                 depth_live = 0.0
                 if rt_fb_hold > 0: rt_fb_hold -= 1
-                frame = draw_overlay(frame, reps=counter, feedback=(rt_fb_msg if rt_fb_hold>0 else None), depth_pct=depth_live)
-                out.write(frame); continue
+                if return_video:
+                    frame = draw_overlay(frame, reps=counter, feedback=(rt_fb_msg if rt_fb_hold>0 else None), depth_pct=depth_live)
+                    if out is not None:
+                        out.write(frame)
+                continue
 
             lm = results.pose_landmarks.landmark
             R = mp_pose.PoseLandmark
@@ -338,8 +346,11 @@ def run_barbell_bicep_curl_analysis(video_path,
             if not angles:
                 if rt_fb_hold > 0: rt_fb_hold -= 1
                 depth_live = 0.0
-                frame = draw_overlay(frame, reps=counter, feedback=(rt_fb_msg if rt_fb_hold>0 else None), depth_pct=depth_live)
-                out.write(frame); continue
+                if return_video:
+                    frame = draw_overlay(frame, reps=counter, feedback=(rt_fb_msg if rt_fb_hold>0 else None), depth_pct=depth_live)
+                    if out is not None:
+                        out.write(frame)
+                continue
             elbow_angle = float(np.mean(angles))
 
             # EMA ליישור תחתית (כמו סקוואט — מתעדכן רק כשהיד כמעט ישרה ושקט תנועתי)
@@ -472,9 +483,11 @@ def run_barbell_bicep_curl_analysis(video_path,
                     rt_fb_hold = 0
 
             # ציור שלד גוף בלבד + Overlay זהה
-            frame = draw_body_only(frame, lm)
-            frame = draw_overlay(frame, reps=counter, feedback=(rt_fb_msg if rt_fb_hold>0 else None), depth_pct=depth_live)
-            out.write(frame)
+            if return_video:
+                frame = draw_body_only(frame, lm)
+                frame = draw_overlay(frame, reps=counter, feedback=(rt_fb_msg if rt_fb_hold>0 else None), depth_pct=depth_live)
+                if out is not None:
+                    out.write(frame)
 
     cap.release()
     if out: out.release()
@@ -497,18 +510,20 @@ def run_barbell_bicep_curl_analysis(video_path,
         pass
 
     # קידוד faststart (כמו בסקוואט)
-    encoded_path = output_path.replace(".mp4", "_encoded.mp4")
-    try:
-        subprocess.run([
-            "ffmpeg", "-y", "-i", output_path,
-            "-c:v", "libx264", "-preset", "fast", "-movflags", "+faststart", "-pix_fmt", "yuv420p",
-            encoded_path
-        ], check=False)
-        if os.path.exists(output_path) and os.path.exists(encoded_path):
-            os.remove(output_path)
-    except Exception:
-        pass
-    final_video_path = encoded_path if os.path.exists(encoded_path) else (output_path if os.path.exists(output_path) else "")
+    final_video_path = ""
+    if return_video and output_path:
+        encoded_path = output_path.replace(".mp4", "_encoded.mp4")
+        try:
+            subprocess.run([
+                "ffmpeg", "-y", "-i", output_path,
+                "-c:v", "libx264", "-preset", "fast", "-movflags", "+faststart", "-pix_fmt", "yuv420p",
+                encoded_path
+            ], check=False)
+            if os.path.exists(output_path) and os.path.exists(encoded_path):
+                os.remove(output_path)
+        except Exception:
+            pass
+        final_video_path = encoded_path if os.path.exists(encoded_path) else (output_path if os.path.exists(output_path) else "")
 
     return {
         "squat_count": counter,  # נשמר לשמירה על תאימות UI קיימת
@@ -519,7 +534,7 @@ def run_barbell_bicep_curl_analysis(video_path,
         "bad_reps": bad_reps,
         "feedback": feedback_list,
         "reps": rep_reports,
-        "video_path": final_video_path,
+        "video_path": final_video_path if return_video else "",
         "feedback_path": feedback_path
     }
 

--- a/pullup_analysis.py
+++ b/pullup_analysis.py
@@ -228,7 +228,9 @@ def run_pullup_analysis(video_path,
         return _ret_err("Mediapipe not available", feedback_path)
 
     model_complexity = 1
-    return_video = True
+    if fast_mode is True:
+        return_video = False
+
 
     if preserve_quality:
         scale=1.0; frame_skip=1; encode_crf=18 if encode_crf is None else encode_crf

--- a/squat_analysis.py
+++ b/squat_analysis.py
@@ -293,7 +293,8 @@ def run_squat_analysis(video_path,
                        scale=0.4,
                        output_path="squat_analyzed.mp4",
                        feedback_path="squat_feedback.txt",
-                       fast_mode=False):
+                       fast_mode=False,
+                       return_video=True):
     mp_pose_mod = mp.solutions.pose
     cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
@@ -304,7 +305,9 @@ def run_squat_analysis(video_path,
             "technique_label": score_label(0.0)
         }
     
-    create_video = (output_path is not None) and (output_path != "")
+    if fast_mode is True:
+        return_video = False
+    create_video = bool(return_video) and (output_path is not None) and (output_path != "")
 
     counter = 0
     good_reps = 0
@@ -720,5 +723,6 @@ def run_analysis(video_path,
                  scale=0.4,
                  output_path="squat_analyzed.mp4",
                  feedback_path="squat_feedback.txt",
-                 fast_mode=False):
-    return run_squat_analysis(video_path, frame_skip, scale, output_path, feedback_path, fast_mode)
+                 fast_mode=False,
+                 return_video=True):
+    return run_squat_analysis(video_path, frame_skip, scale, output_path, feedback_path, fast_mode, return_video)


### PR DESCRIPTION
### Motivation
- Allow a fast analysis path that returns JSON only (no processed video) and a slow path that also produces an analyzed video, while keeping existing scoring and rep-detection logic unchanged. 
- Reduce work/IO in low-latency usage (server fast mode) and preserve full video output for the full analysis path when requested. 

### Description
- Added `return_video` and `fast_mode` parameters to the analyzers and adapted `squat_analysis.py`, `bulgarian_split_squat_analysis.py`, `barbell_bicep_curl.py`, `bent_over_row_analysis.py`, and `pullup_analysis.py` to honor those flags. 
- Gate creation of `VideoWriter`, per-frame overlay writes, and FFmpeg remux/encode behind `return_video` (and set `return_video=False` when `fast_mode=True`). 
- Ensure analyzers return an empty `video_path` when running in fast/no-video mode and preserve all rep/score/feedback outputs unchanged. 
- Kept internal behavior and scoring logic intact and only changed video-output/code-path gating.

### Testing
- Compiled the modified modules with `python -m py_compile app.py squat_analysis.py bulgarian_split_squat_analysis.py barbell_bicep_curl.py bent_over_row_analysis.py pullup_analysis.py`, which succeeded. 
- Attempted a lightweight import/signature smoke test for the analyzer functions, but it failed at runtime due to the environment missing `libGL.so.1` (OpenCV import error), which is an environment issue rather than a code error. 
- Verified file diffs and that analyzer signatures now include `return_video`/`fast_mode` as intended (static inspection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698497f921a883238c6ac2cb3b26676c)