### PR TITLE
Report multipart upload disconnects as timeouts and restore RDL fast-mode sampling

### DIFF
--- a/app.py
+++ b/app.py
@@ -300,11 +300,11 @@ def analyze():
                   file=sys.stderr, flush=True)
             return jsonify({
                 "error": "client_disconnected",
-                "detail": "Upload interrupted before the multipart payload was fully received",
+                "detail": "Upload interrupted before the multipart payload was fully received (client/proxy timeout or connection drop)",
                 "content_length": content_length,
                 "size_mb": size_mb,
                 "hint": "Client/proxy timed out during upload. Retry on better network, send smaller/compressed video, or use raw video upload (Content-Type: video/mp4 with ?exercise_type=...&fast=true)."
-            }), 400
+            }), 408
 
         video_file = files.get('video')
         if not video_file:

--- a/romanian_deadlift_analysis.py
+++ b/romanian_deadlift_analysis.py
@@ -251,6 +251,8 @@ def run_romanian_deadlift_analysis(video_path,
     print(f"[RDL] Starting analysis: fast_mode={fast_mode}, return_video={return_video}", file=sys.stderr, flush=True)
     print(f"[RDL] Video path: {video_path}", file=sys.stderr, flush=True)
     
+    mp_pose_mod = mp.solutions.pose
+
     # === רק זה משתנה: האם ליצור וידאו ===
     if fast_mode is True:
         return_video = False
@@ -289,10 +291,21 @@ def run_romanian_deadlift_analysis(video_path,
             "reps": [], "video_path": "", "feedback_path": feedback_path
         }
 
+    # במצב מהיר: שומרים על בדיקת פריימים זהה, scale מעט קטן יותר, model lite
+    if fast_mode:
+        effective_frame_skip = frame_skip
+        effective_scale = scale * 0.85
+        model_complexity = 0
+        print(f"[RDL FAST] frame_skip={effective_frame_skip}, scale={effective_scale:.2f}, model=lite", file=sys.stderr, flush=True)
+    else:
+        effective_frame_skip = frame_skip
+        effective_scale = scale
+        model_complexity = 1
+
     fourcc = cv2.VideoWriter_fourcc(*'mp4v')
     out = None
     fps_in = cap.get(cv2.CAP_PROP_FPS) or 25
-    effective_fps = max(1.0, fps_in / max(1, frame_skip))  # ✅ חזרנו לערך המקורי
+    effective_fps = max(1.0, fps_in / max(1, effective_frame_skip))
     dt = 1.0 / float(effective_fps)
 
     counter = good_reps = bad_reps = 0
@@ -318,7 +331,7 @@ def run_romanian_deadlift_analysis(video_path,
     rt_fb_msg = None
     rt_fb_hold = 0
 
-    # ✅ חזרנו למודל המקורי - model_complexity=1 תמיד
+    # מודל מהיר/איטי לפי fast_mode
     print(f"[RDL] Starting pose detection loop", file=sys.stderr, flush=True)
     
     import time
@@ -326,9 +339,9 @@ def run_romanian_deadlift_analysis(video_path,
     MAX_PROCESSING_TIME = 180  # 3 דקות מקסימום
     frames_processed = 0
     
-    with mp_pose.Pose(model_complexity=1,  # ✅ לא משנים את המודל!
-                      min_detection_confidence=0.5,
-                      min_tracking_confidence=0.5) as pose:
+    with mp_pose_mod.Pose(model_complexity=model_complexity,
+                          min_detection_confidence=0.5,
+                          min_tracking_confidence=0.5) as pose:
         while cap.isOpened():
             ret, frame = cap.read()
             if not ret:
@@ -341,7 +354,7 @@ def run_romanian_deadlift_analysis(video_path,
                 break
             
             frame_idx += 1
-            if frame_idx % frame_skip != 0:  # ✅ חזרנו ל-frame_skip המקורי
+            if frame_idx % effective_frame_skip != 0:
                 continue
             
             frames_processed += 1
@@ -350,7 +363,7 @@ def run_romanian_deadlift_analysis(video_path,
             if frames_processed % 30 == 0:
                 print(f"[RDL] Progress: {frames_processed} frames, {counter} reps, {elapsed:.1f}s", file=sys.stderr, flush=True)
 
-            work = cv2.resize(frame, (0, 0), fx=scale, fy=scale) if scale != 1.0 else frame  # ✅ חזרנו ל-scale המקורי
+            work = cv2.resize(frame, (0, 0), fx=effective_scale, fy=effective_scale) if effective_scale != 1.0 else frame
             if create_video and out is None:
                 h0, w0 = work.shape[:2]
                 out = cv2.VideoWriter(output_path, fourcc, effective_fps, (w0, h0))


### PR DESCRIPTION
### Motivation
- Return a clearer, semantically-correct status when multipart uploads disconnect mid-stream by distinguishing client/proxy timeouts from generic bad requests.
- Restore accurate Romanian Deadlift analysis behavior in `fast_mode` by keeping the original frame sampling while still reducing processing cost and switching to a lite pose model.

### Description
- In `app.py` change the multipart parsing error handler to return HTTP `408` with an expanded `detail` message and preserve the existing retry/hint text (`client_disconnected` response now includes `content_length` and `size_mb`).
- In `romanian_deadlift_analysis.py` introduce `mp_pose_mod = mp.solutions.pose` and use `mp_pose_mod.Pose(model_complexity=...)` so the pose model complexity can be toggled per mode.
- Add `effective_frame_skip`, `effective_scale`, and `model_complexity` and compute `effective_fps` from `effective_frame_skip` so `fast_mode` keeps the original frame sampling while using `effective_scale = scale * 0.85` and `model_complexity = 0`.
- Use `effective_scale` for frame resizing and build the `VideoWriter` from the resized `work.shape`, and ensure `fast_mode` sets `return_video=False` so overlays/writing are skipped when appropriate, while the analysis logic remains identical.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69889cb4bd848323ba04fa67a5fed611)