### PR TITLE
Align stiff-leg deadlift rep counting and update positive feedback

### DIFF
--- a/stiff_leg_deadlift_analysis.py
+++ b/stiff_leg_deadlift_analysis.py
@@ -377,8 +377,8 @@ def run_stiff_leg_deadlift_analysis(video_path,
                 if torso_angle >= HINGE_BOTTOM_ANGLE:
                     bottom_reached = True
 
-                # ✅✅ תיקון ספירה: תנאי פשוט יותר - אם הגיע למטה וחזר למעלה (מתחת ל-25°)
-                if bottom_reached and torso_angle <= 25.0 and (frame_idx - last_rep_frame) >= MIN_FRAMES_BETWEEN_REPS:
+                # ✅✅ תיקון ספירה: זהה לדדליפט רומני - חזרה נספרת רק כשחוזרים ל-stand angle
+                if bottom_reached and torso_angle <= STAND_ANGLE and (frame_idx - last_rep_frame) >= MIN_FRAMES_BETWEEN_REPS:
                     last_rep_frame = frame_idx
                     counter += 1
 
@@ -459,7 +459,7 @@ def run_stiff_leg_deadlift_analysis(video_path,
     if session_feedbacks:
         technique_score = min(technique_score, 9.5)
 
-    feedback_list = dedupe_feedback(session_feedbacks) if session_feedbacks else ["Excellent form! 🔥"]
+    feedback_list = dedupe_feedback(session_feedbacks) if session_feedbacks else ["Great form! Keep it up 💪"]
 
     session_tip = None
     if session_feedback_by_cat:


### PR DESCRIPTION
### Motivation
- Make stiff‑leg deadlift rep counting consistent with the Romanian deadlift logic and normalize the positive feedback text for perfect reps.

### Description
- In `stiff_leg_deadlift_analysis.py` change the rep completion check to use `STAND_ANGLE` (instead of the hardcoded `25.0`) so a rep is counted only when the torso returns to the stand angle, matching the Romanian deadlift logic.
- Update the default session feedback message from `"Excellent form! 🔥"` to `"Great form! Keep it up 💪"`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a1ee017308323918447baec8bf4e5)