### PR TITLE
Relax Romanian deadlift lowering check

### DIFF
--- a/romanian_deadlift_analysis.py
+++ b/romanian_deadlift_analysis.py
@@ -229,7 +229,7 @@ BACK_MAX_ANGLE = 45.0
 # ✅✅✅ תיקון קריטי: הקלה משמעותית בדרישות הזמן
 # בדדליפט רומני, הירידה צריכה להיות **מבוקרת** אבל לא בהכרח איטית מאוד
 # התנאי הרגוע יותר יתריע רק על נפילה חופשית ממש
-MIN_ECC_S = 0.08  # ✅ ירידה מבוקרת (רק נגד נפילה חופשית)
+MIN_ECC_S = 0.05  # ✅ ירידה מבוקרת (רק נגד נפילה חופשית)
 MIN_BOTTOM_S = 0.05  # ✅ השהייה מינימלית בתחתית
 
 MIN_SCORE = 4.0
@@ -446,7 +446,7 @@ def run_romanian_deadlift_analysis(video_path,
                     # ✅✅ בדיקת טמפו - תנאי מרוכך מאוד (רק נגד נפילה חופשית)
                     if down_s < MIN_ECC_S:
                         feedback.append("Control the lowering")
-                        score -= 0.3  # ✅ עונש מינימלי
+                        score -= 0.2  # ✅ עונש מינימלי
 
                     if bottom_s < MIN_BOTTOM_S:
                         feedback.append("Pause at the bottom")


### PR DESCRIPTION
### Motivation
- The tempo check for Romanian deadlifts was flagging controlled but not slow lowerings as failures, so the lowering timing threshold and penalty were relaxed to reduce false positives.

### Description
- In `romanian_deadlift_analysis.py` the eccentric timing threshold `MIN_ECC_S` was lowered from `0.08` to `0.05` and the score penalty for `Control the lowering` was reduced from `0.3` to `0.2`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a2081961c8323940e796b4df3f71c)