### PR TITLE
Restore sensible lowering check for Romanian deadlift (min frames + time floor)

### DIFF
--- a/romanian_deadlift_analysis.py
+++ b/romanian_deadlift_analysis.py
@@ -229,7 +229,7 @@ BACK_MAX_ANGLE = 45.0
 # ✅✅✅ תיקון קריטי: הקלה משמעותית בדרישות הזמן
 # בדדליפט רומני, הירידה צריכה להיות **מבוקרת** אבל לא בהכרח איטית מאוד
 # התנאי הרגוע יותר יתריע רק על נפילה חופשית ממש
-MIN_ECC_S = 0.08  # ✅ ירידה מבוקרת (רק נגד נפילה חופשית)
+MIN_ECC_S = 0.12  # ✅ ירידה מבוקרת (רק נגד נפילה חופשית)
 MIN_BOTTOM_S = 0.05  # ✅ השהייה מינימלית בתחתית
 
 MIN_SCORE = 4.0
@@ -246,7 +246,7 @@ def run_romanian_deadlift_analysis(video_path,
     Romanian Deadlift analysis - FIXED:
     ✅ ברכיים: מותר עיקום 160-170 מעלות (עיקום קל)
     ✅ גב: מותר נטייה עד 45 מעלות
-    ✅✅✅ זמן ירידה: 0.08 שניות מספיק (רק נגד נפילה חופשית)
+    ✅✅✅ זמן ירידה: סף מינימלי + 2 פריימים (רק נגד נפילה חופשית)
     ✅ fast_mode: במצב מהיר - אותה לוגיקה בדיוק, רק ללא ציור וידאו
     """
     import sys
@@ -444,9 +444,11 @@ def run_romanian_deadlift_analysis(video_path,
                         score -= 1.0
 
                     # ✅✅ בדיקת טמפו - תנאי מרוכך מאוד (רק נגד נפילה חופשית)
-                    if down_s < MIN_ECC_S:
+                    # דורש לפחות שני פריימים של ירידה, או סף זמן מינימלי
+                    min_ecc_s = max(MIN_ECC_S, 2 * dt)
+                    if down_s < min_ecc_s:
                         feedback.append("Control the lowering")
-                        score -= 0.3  # ✅ עונש מינימלי
+                        score -= 0.1  # ✅ עונש מינימלי
 
                     if bottom_s < MIN_BOTTOM_S:
                         feedback.append("Pause at the bottom")


### PR DESCRIPTION
### Motivation
- The previous change effectively disabled the "Control the lowering" check and produced user complaints, so the lowering rule needed a simple, logical condition that flags true free-fall but not normal executions. 
- The intent is to avoid false positives while still catching real uncontrolled drops.

### Description
- Updated `romanian_deadlift_analysis.py` to set `MIN_ECC_S = 0.12` as a reasonable eccentric-time floor. 
- Added a runtime minimum-eccentric-duration calculation `min_ecc_s = max(MIN_ECC_S, 2 * dt)` to require at least two frames of descent or the time floor before triggering the lowering warning. 
- Switched the lowering check to `if down_s < min_ecc_s:` and reduced the associated penalty to `score -= 0.1` to make the feedback less punitive. 
- Updated the function docstring/comments to reflect the new logic and kept all changes localized to `romanian_deadlift_analysis.py`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a2081961c8323940e796b4df3f71c)