### PR TITLE
Return 501 when analyzer module is missing

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,6 +66,13 @@ def _standardize_video_path(result_dict):
             result_dict["video_path"] = result_dict["analyzed_video_path"]
     return result_dict
 
+def _is_analyzer_unavailable(result_dict):
+    return isinstance(result_dict, dict) and result_dict.get("error") == "analyzer_unavailable"
+
+def _unavailable_response(result_dict):
+    detail = result_dict.get("detail") if isinstance(result_dict, dict) else "Analyzer unavailable"
+    return jsonify({"error": "analyzer_unavailable", "detail": detail}), 501
+
 def _normalize_analysis_fields(result_dict):
     """Ensure analyzer responses contain stable numeric fields for downstream UI."""
     if not isinstance(result_dict, dict):
@@ -311,6 +318,8 @@ def analyze():
                 result = {"error": "invalid_result", 
                          "detail": "Analyzer did not return a dict", 
                          "video_path": ""}
+            if _is_analyzer_unavailable(result):
+                return _unavailable_response(result)
 
             result = _standardize_video_path(result)
             output_path = result.get("video_path") or ""
@@ -405,6 +414,8 @@ def analyze():
             result = {"error": "invalid_result", 
                      "detail": "Analyzer did not return a dict", 
                      "video_path": ""}
+        if _is_analyzer_unavailable(result):
+            return _unavailable_response(result)
 
         result = _standardize_video_path(result)
         output_path = result.get("video_path") or ""


### PR DESCRIPTION
### Motivation
- The soft loader returns an error object (`error: "analyzer_unavailable"`) when an analyzer module or function is missing, which previously propagated as a successful 200 response with no real analysis result. 
- Make unavailable analyzers surface as an explicit HTTP error so clients can distinguish a missing analyzer from an actual (empty) analysis.

### Description
- Add helper `
`_is_analyzer_unavailable` to detect analyzer-unavailable result objects and `
`_unavailable_response` to produce a JSON 501 response with a clear `error`/`detail` payload.
- After calling `
`_do_analyze` in both the raw upload flow and the multipart/form-data flow, return `
`_unavailable_response(result)` when `_is_analyzer_unavailable(result)` is true.
- Preserve existing handling for non-dict/invalid analyzer returns and the `
`_standardize_video_path`/`_normalize_analysis_fields` behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a2e3d5bdc83238b08be68dfe06331)