### PR TITLE
Improve push-up analysis robustness and fast-rep detection

### DIFF
--- a/pushup_analysis.py
+++ b/pushup_analysis.py
@@ -128,13 +128,13 @@ def draw_overlay(frame, reps=0, feedback=None, depth_pct=0.0):
     return cv2.cvtColor(np.array(pil),cv2.COLOR_RGB2BGR)
 
 # ============ IMPROVED Motion Detection - better for fast speeds ============
-BASE_FRAME_SKIP = 3
+BASE_FRAME_SKIP = 2
 ACTIVE_FRAME_SKIP = 1
 MOTION_DETECTION_WINDOW = 8
-MOTION_VEL_THRESHOLD = 0.0011       # מעט יותר רגיש
-MOTION_ACCEL_THRESHOLD = 0.0007     # מעט יותר רגיש
-ELBOW_CHANGE_THRESHOLD = 5.5        # מעט יותר רגיש
-COOLDOWN_FRAMES = 23                # קצת יותר זמן
+MOTION_VEL_THRESHOLD = 0.0010       # יותר רגיש לתנועה מהירה
+MOTION_ACCEL_THRESHOLD = 0.0006     # יותר רגיש לשינויי קצב
+ELBOW_CHANGE_THRESHOLD = 5.0        # יותר רגיש לשינוי בזווית מרפק
+COOLDOWN_FRAMES = 26                # שומר חלון פעילות מעט ארוך יותר
 MIN_VEL_FOR_MOTION = 0.0004
 
 class MotionDetector:
@@ -256,8 +256,8 @@ class MotionDetector:
         }
 
 # ============ Slightly More Forgiving Parameters - BUT STRICTER DEPTH ============
-ELBOW_BENT_ANGLE = 100.0            # ✅ סף ספירה קפדני יותר (היה 107)
-SHOULDER_MIN_DESCENT = 0.039        # קצת פחות
+ELBOW_BENT_ANGLE = 102.0            # מעט סלחני יותר כדי לא לפספס חזרות מהירות
+SHOULDER_MIN_DESCENT = 0.036        # סף ירידה מעט נמוך יותר לחזרות מהירות
 RESET_ASCENT = 0.024                # קצת מהיר יותר
 RESET_ELBOW = 153.0                 # קצת מהיר יותר
 REFRACTORY_FRAMES = 1               # מינימום
@@ -339,6 +339,11 @@ DEBUG_ONPUSHUP = bool(int(os.getenv("DEBUG_ONPUSHUP", "0")))
 DEBUG_MOTION = bool(int(os.getenv("DEBUG_MOTION", "0")))
 DEBUG_GRADING = bool(int(os.getenv("DEBUG_GRADING", "1")))
 
+MIN_CYCLE_ELBOW_SAMPLES = 4
+ROBUST_BOTTOM_PERCENTILE = 25
+ROBUST_TOP_PERCENTILE = 75
+
+
 def run_pushup_analysis(video_path,
                         frame_skip=None,
                         scale=0.4,
@@ -402,6 +407,7 @@ def run_pushup_analysis(video_path,
     rt_fb_msg=None; rt_fb_hold=0
 
     cycle_tip_deeper=False; cycle_tip_hips=False; cycle_tip_lockout=False; cycle_tip_elbows=False
+    cycle_bottom_samples=[]; cycle_top_samples=[]
     depth_fail_count=0; hips_fail_count=0; lockout_fail_count=0; flare_fail_count=0
     depth_already_reported=False; hips_already_reported=False
     lockout_already_reported=False; flare_already_reported=False
@@ -503,6 +509,7 @@ def run_pushup_analysis(video_path,
                 desc_base_shoulder=None; allow_new_bottom=True
                 cycle_max_descent=0.0; cycle_min_elbow=999.0; counted_this_cycle=False
                 cycle_tip_deeper=False; cycle_tip_hips=False; cycle_tip_lockout=False; cycle_tip_elbows=False
+                cycle_bottom_samples=[]; cycle_top_samples=[]
                 bottom_phase_min_elbow=None; top_phase_max_elbow=None
                 cycle_max_hip_misalign=None; cycle_max_flare=None
                 cycle_max_descent_vel=0.0
@@ -510,7 +517,8 @@ def run_pushup_analysis(video_path,
                 motion_detector.activate("enter_plank")
 
             if onpushup and offpushup_streak>=OFFPUSHUP_MIN_FRAMES:
-                cycle_has_issues = _evaluate_cycle_form(lms, bottom_phase_min_elbow, top_phase_max_elbow,
+                robust_bottom_elbow, robust_top_elbow = _robust_cycle_elbows(cycle_bottom_samples, cycle_top_samples, bottom_phase_min_elbow, top_phase_max_elbow)
+                cycle_has_issues = _evaluate_cycle_form(lms, robust_bottom_elbow, robust_top_elbow,
                                    cycle_max_hip_misalign, cycle_max_flare,
                                    cycle_max_descent_vel,
                                    depth_fail_count, hips_fail_count, lockout_fail_count, flare_fail_count,
@@ -524,7 +532,7 @@ def run_pushup_analysis(video_path,
                                desc_base_shoulder if desc_base_shoulder is not None else shoulder_y,
                                baseline_shoulder_y+cycle_max_descent if baseline_shoulder_y is not None else shoulder_y,
                                all_scores, cycle_has_issues,  # ✅ Use return value
-                               bottom_phase_min_elbow, top_phase_max_elbow, 
+                               robust_bottom_elbow, robust_top_elbow, 
                                cycle_max_hip_misalign, cycle_max_flare)
                     rep_count+=1
                     if cycle_has_issues: bad_reps+=1  # ✅ Use return value
@@ -533,6 +541,7 @@ def run_pushup_analysis(video_path,
                 onpushup=False; offpushup_frames_since_any_rep=0
                 desc_base_shoulder=None; cycle_max_descent=0.0; cycle_min_elbow=999.0; counted_this_cycle=False
                 cycle_tip_deeper=False; cycle_tip_hips=False; cycle_tip_lockout=False; cycle_tip_elbows=False
+                cycle_bottom_samples=[]; cycle_top_samples=[]
                 bottom_phase_min_elbow=None; top_phase_max_elbow=None
                 cycle_max_hip_misalign=None; cycle_max_flare=None
                 cycle_max_descent_vel=0.0
@@ -557,6 +566,7 @@ def run_pushup_analysis(video_path,
                     if shoulder_vel>abs(INFLECT_VEL_THR):
                         desc_base_shoulder=shoulder_y
                         cycle_max_descent=0.0; cycle_min_elbow=elbow_angle; counted_this_cycle=False
+                        cycle_bottom_samples=[]; cycle_top_samples=[]
                         bottom_phase_min_elbow=None; top_phase_max_elbow=None
                         cycle_max_hip_misalign=None; cycle_max_flare=None
                         cycle_max_descent_vel=0.0
@@ -575,10 +585,16 @@ def run_pushup_analysis(video_path,
                         cycle_max_descent_vel = max(cycle_max_descent_vel, vel_abs)
 
                     min_elb_now = min(raw_elbow_L, raw_elbow_R)
+                    cycle_bottom_samples.append(min_elb_now)
+                    if len(cycle_bottom_samples) > 40:
+                        cycle_bottom_samples.pop(0)
                     if bottom_phase_min_elbow is None: bottom_phase_min_elbow = min_elb_now
                     else: bottom_phase_min_elbow = min(bottom_phase_min_elbow, min_elb_now)
 
                     max_elb_now = max(raw_elbow_L, raw_elbow_R)
+                    cycle_top_samples.append(max_elb_now)
+                    if len(cycle_top_samples) > 40:
+                        cycle_top_samples.pop(0)
                     if top_phase_max_elbow is None: top_phase_max_elbow = max_elb_now
                     else: top_phase_max_elbow = max(top_phase_max_elbow, max_elb_now)
 
@@ -597,7 +613,10 @@ def run_pushup_analysis(video_path,
                         in_descent_phase = False
                     
                     if reset_by_asc or reset_by_elb:
-                        cycle_has_issues = _evaluate_cycle_form(lms, bottom_phase_min_elbow, top_phase_max_elbow,
+                        robust_bottom_elbow, robust_top_elbow = _robust_cycle_elbows(
+                            cycle_bottom_samples, cycle_top_samples, bottom_phase_min_elbow, top_phase_max_elbow
+                        )
+                        cycle_has_issues = _evaluate_cycle_form(lms, robust_bottom_elbow, robust_top_elbow,
                                            cycle_max_hip_misalign, cycle_max_flare,
                                            cycle_max_descent_vel,
                                            depth_fail_count, hips_fail_count, lockout_fail_count, flare_fail_count,
@@ -610,16 +629,17 @@ def run_pushup_analysis(video_path,
                             _count_rep(rep_reports,rep_count,cycle_min_elbow,
                                        desc_base_shoulder,
                                        baseline_shoulder_y+cycle_max_descent if baseline_shoulder_y is not None else shoulder_y,
-                                       all_scores, cycle_has_issues,  # ✅
-                                       bottom_phase_min_elbow, top_phase_max_elbow,
+                                       all_scores, cycle_has_issues,
+                                       robust_bottom_elbow, robust_top_elbow,
                                        cycle_max_hip_misalign, cycle_max_flare)
                             rep_count+=1
-                            if cycle_has_issues: bad_reps+=1  # ✅
+                            if cycle_has_issues: bad_reps+=1
                             else: good_reps+=1
 
                         desc_base_shoulder=shoulder_y
                         cycle_max_descent=0.0; cycle_min_elbow=elbow_angle; counted_this_cycle=False
                         allow_new_bottom=True
+                        cycle_bottom_samples=[]; cycle_top_samples=[]
                         bottom_phase_min_elbow=None; top_phase_max_elbow=None
                         cycle_max_hip_misalign=None; cycle_max_flare=None
                         cycle_max_descent_vel=0.0
@@ -637,9 +657,10 @@ def run_pushup_analysis(video_path,
                 if at_bottom and allow_new_bottom and can_cnt and (not counted_this_cycle):
                     # ✅ Calculate if has issues based on current measurements
                     rep_has_issues = False
-                    if bottom_phase_min_elbow and bottom_phase_min_elbow > DEPTH_FAIR_ANGLE:
+                    robust_bottom_elbow, robust_top_elbow = _robust_cycle_elbows(cycle_bottom_samples, cycle_top_samples, bottom_phase_min_elbow, top_phase_max_elbow)
+                    if robust_bottom_elbow and robust_bottom_elbow > DEPTH_FAIR_ANGLE:
                         rep_has_issues = True
-                    if top_phase_max_elbow and top_phase_max_elbow < LOCKOUT_GOOD:
+                    if robust_top_elbow and robust_top_elbow < LOCKOUT_GOOD:
                         rep_has_issues = True
                     if cycle_max_hip_misalign and cycle_max_hip_misalign > HIP_FAIR:
                         rep_has_issues = True
@@ -649,8 +670,8 @@ def run_pushup_analysis(video_path,
                     _count_rep(rep_reports,rep_count,elbow_angle,
                                desc_base_shoulder if desc_base_shoulder is not None else shoulder_y, shoulder_y,
                                all_scores, rep_has_issues,  # ✅
-                               bottom_phase_min_elbow if bottom_phase_min_elbow else raw_elbow_min,
-                               top_phase_max_elbow if top_phase_max_elbow else max(raw_elbow_L, raw_elbow_R),
+                               robust_bottom_elbow if robust_bottom_elbow else raw_elbow_min,
+                               robust_top_elbow if robust_top_elbow else max(raw_elbow_L, raw_elbow_R),
                                cycle_max_hip_misalign if cycle_max_hip_misalign else 0.0,
                                cycle_max_flare if cycle_max_flare else 0.0)
                     rep_count+=1
@@ -667,7 +688,8 @@ def run_pushup_analysis(video_path,
                             allow_new_bottom=True
 
                 if at_bottom and not cycle_tip_deeper:
-                    if bottom_phase_min_elbow and bottom_phase_min_elbow > DEPTH_GOOD_ANGLE:
+                    robust_bottom_elbow, _ = _robust_cycle_elbows(cycle_bottom_samples, cycle_top_samples, bottom_phase_min_elbow, top_phase_max_elbow)
+                    if robust_bottom_elbow and robust_bottom_elbow > DEPTH_GOOD_ANGLE:
                         cycle_tip_deeper = True
                         depth_fail_count += 1
                         if depth_fail_count >= DEPTH_FAIL_MIN_REPS and not depth_already_reported:
@@ -692,7 +714,8 @@ def run_pushup_analysis(video_path,
             if shoulder_y is not None: shoulder_prev=shoulder_y
 
     if onpushup and (not counted_this_cycle) and (cycle_max_descent>=SHOULDER_MIN_DESCENT) and (cycle_min_elbow<=ELBOW_BENT_ANGLE):
-        cycle_has_issues = _evaluate_cycle_form(lms, bottom_phase_min_elbow, top_phase_max_elbow,
+        robust_bottom_elbow, robust_top_elbow = _robust_cycle_elbows(cycle_bottom_samples, cycle_top_samples, bottom_phase_min_elbow, top_phase_max_elbow)
+        cycle_has_issues = _evaluate_cycle_form(lms, robust_bottom_elbow, robust_top_elbow,
                            cycle_max_hip_misalign, cycle_max_flare,
                            cycle_max_descent_vel,
                            depth_fail_count, hips_fail_count, lockout_fail_count, flare_fail_count,
@@ -705,7 +728,7 @@ def run_pushup_analysis(video_path,
                    desc_base_shoulder if desc_base_shoulder is not None else (baseline_shoulder_y or 0.0),
                    (baseline_shoulder_y + cycle_max_descent) if baseline_shoulder_y is not None else (baseline_shoulder_y or 0.0),
                    all_scores, cycle_has_issues,  # ✅
-                   bottom_phase_min_elbow, top_phase_max_elbow,
+                   robust_bottom_elbow, robust_top_elbow,
                    cycle_max_hip_misalign, cycle_max_flare)
         rep_count+=1
         if cycle_has_issues: bad_reps+=1  # ✅
@@ -808,6 +831,20 @@ def run_pushup_analysis(video_path,
     return result
 
 # ============ Helper Functions ============
+
+def _robust_cycle_elbows(bottom_samples, top_samples, fallback_bottom=None, fallback_top=None):
+    robust_bottom = fallback_bottom
+    robust_top = fallback_top
+
+    if bottom_samples:
+        arr = np.array(bottom_samples, dtype=np.float32)
+        robust_bottom = float(np.percentile(arr, ROBUST_BOTTOM_PERCENTILE))
+    if top_samples:
+        arr = np.array(top_samples, dtype=np.float32)
+        robust_top = float(np.percentile(arr, ROBUST_TOP_PERCENTILE))
+
+    return robust_bottom, robust_top
+
 def _calculate_body_angle(lms, LSH, RSH, LH, RH, LA, RA):
     mid_sh = ((lms[LSH].x + lms[RSH].x)/2.0, (lms[LSH].y + lms[RSH].y)/2.0)
     mid_ank = ((lms[LA].x + lms[RA].x)/2.0, (lms[LA].y + lms[RA].y)/2.0)
@@ -859,7 +896,7 @@ def _evaluate_cycle_form(lms, bottom_phase_min_elbow, top_phase_max_elbow,
     has_flare_issue = False
     
     # Form errors - מורידים נקודות
-    if bottom_phase_min_elbow is not None:
+    if bottom_phase_min_elbow is not None and local_vars.get("cycle_bottom_samples") and len(local_vars["cycle_bottom_samples"]) >= MIN_CYCLE_ELBOW_SAMPLES:
         if bottom_phase_min_elbow > DEPTH_FAIR_ANGLE:
             has_depth_issue = True  # ✅
             local_vars['cycle_tip_deeper'] = True
@@ -868,7 +905,7 @@ def _evaluate_cycle_form(lms, bottom_phase_min_elbow, top_phase_max_elbow,
                 session_form_errors.add(FB_ERROR_DEPTH)
                 local_vars['depth_already_reported'] = True
 
-    if top_phase_max_elbow is not None:
+    if top_phase_max_elbow is not None and local_vars.get("cycle_top_samples") and len(local_vars["cycle_top_samples"]) >= MIN_CYCLE_ELBOW_SAMPLES:
         if top_phase_max_elbow < LOCKOUT_GOOD:
             has_lockout_issue = True  # ✅
             local_vars['cycle_tip_lockout'] = True


### PR DESCRIPTION
### Motivation
- Reduce missed fast/short push-up reps and avoid single-frame outliers causing incorrect depth/lockout scoring. 
- Make motion activation more sensitive so the processor engages earlier during brief movements. 
- Aggregate elbow samples over a cycle and use robust statistics to avoid false positives from noisy frames.

### Description
- Lowered frame-skipping and tuned motion thresholds by changing `BASE_FRAME_SKIP`, `MOTION_VEL_THRESHOLD`, `MOTION_ACCEL_THRESHOLD`, `ELBOW_CHANGE_THRESHOLD`, and `COOLDOWN_FRAMES` to improve fast-rep detection. 
- Relaxed counting thresholds by adjusting `ELBOW_BENT_ANGLE` and `SHOULDER_MIN_DESCENT` to better capture quick valid reps. 
- Added cycle-level sample buffers `cycle_bottom_samples` and `cycle_top_samples` and constants `MIN_CYCLE_ELBOW_SAMPLES`, `ROBUST_BOTTOM_PERCENTILE`, and `ROBUST_TOP_PERCENTILE`. 
- Implemented `_robust_cycle_elbows` to compute percentile-based robust bottom/top elbow values and switched evaluation/`_count_rep` calls to use these robust metrics in place of single-frame min/max values. 
- Integrated robust checks into `_evaluate_cycle_form` so depth/lockout penalties require a minimum number of elbow samples before being applied.

### Testing
- Ran `python -m py_compile pushup_analysis.py` to validate syntax and the file compiled successfully. 
- Attempted a runtime import test with `python - <<'PY'\nimport pushup_analysis\nprint('ok', pushup_analysis.ELBOW_BENT_ANGLE, pushup_analysis.SHOULDER_MIN_DESCENT)\nPY` which failed due to the environment missing the OpenCV system dependency `libGL.so.1`, unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb60648348323b16d512586159c2b)