### PR TITLE
Fix missing 3rd RDL rep and reduce contradictory form feedback

### DIFF
--- a/romanian_deadlift_analysis.py
+++ b/romanian_deadlift_analysis.py
@@ -389,7 +389,7 @@ def compute_movement_signal(all_lm):
 class RepCounter:
     """
     State machine לספירת חזרות עם peak/valley detection.
-    
+
     עובד על סיגנל מורכב (0=עמידה, 1=תחתית) עם היסטרזיס:
     - מזהה מעבר לאזור "כניסה" (threshold_enter)
     - מחפש שיא (peak) של הסיגנל
@@ -402,7 +402,12 @@ class RepCounter:
     EXIT_THRESHOLD = 0.15        # סיגנל מתחת לזה = חזרה לעמידה
     MIN_PEAK_FOR_REP = 0.40      # שיא מינימלי כדי לספור חזרה
     GOOD_DEPTH_PEAK = 0.55       # שיא שנחשב לעומק טוב
-    MIN_FRAMES_BETWEEN = 8       # מינימום פריימים בין חזרות
+    MIN_FRAMES_BETWEEN = 4       # מינימום פריימים בין חזרות
+    MAX_REP_FRAMES = 120         # timeout safety for noisy / oblique angles
+    REBOUND_DELTA = 0.015        # rise after valley means movement turned down again
+    MIN_RETURN_FROM_PEAK = 0.04  # require partial return toward top between reps
+    NORMALIZED_PEAK_THRESHOLD = 0.58
+    NORMALIZED_DROP_THRESHOLD = 0.10
 
     def __init__(self):
         self.state = "standing"  # standing | descending | ascending
@@ -412,6 +417,8 @@ class RepCounter:
         self.last_rep_frame = -999
         self.signal_history = []  # for smoothing
         self.smoothed = 0.0
+        self.rep_start_frame = -1
+        self.ascent_valley = 1.0
 
         # Per-rep metrics
         self.rep_max_torso_2d = 0.0
@@ -425,12 +432,27 @@ class RepCounter:
         self.calibration_signals = []
         self.calibrated = False
         self.standing_baseline = 0.0
+        self.dynamic_floor = 0.0
+        self.dynamic_ceil = 0.6
 
     def _smooth(self, raw_signal):
         """EMA smoothing to reduce noise."""
         alpha = 0.35
         self.smoothed = self.smoothed + alpha * (raw_signal - self.smoothed)
         return self.smoothed
+
+    def _normalize_by_session_range(self, smoothed_signal):
+        """
+        Normalize by evolving floor/ceiling so counting works better
+        when camera angle compresses the raw signal range.
+        """
+        # Slow floor update, slightly faster ceiling update.
+        self.dynamic_floor = 0.98 * self.dynamic_floor + 0.02 * min(self.dynamic_floor, smoothed_signal)
+        self.dynamic_ceil = 0.95 * self.dynamic_ceil + 0.05 * max(self.dynamic_ceil, smoothed_signal)
+
+        rng = max(0.20, self.dynamic_ceil - self.dynamic_floor)
+        normalized = (smoothed_signal - self.dynamic_floor) / rng
+        return float(np.clip(normalized, 0.0, 1.0))
 
     def _calibrate(self, signal):
         """
@@ -442,10 +464,70 @@ class RepCounter:
         if len(self.calibration_signals) >= 15:
             # Standing baseline = minimum of first signals (likely standing)
             self.standing_baseline = float(np.percentile(self.calibration_signals, 25))
+            self.dynamic_floor = self.standing_baseline
+            self.dynamic_ceil = max(self.standing_baseline + 0.35, float(np.percentile(self.calibration_signals, 90)))
             # Adjust thresholds relative to baseline
             self.ENTER_THRESHOLD = max(0.15, self.standing_baseline + 0.15)
             self.EXIT_THRESHOLD = max(0.10, self.standing_baseline + 0.08)
             self.calibrated = True
+
+    def _start_rep_tracking(self, signal_data, frame_idx, smoothed):
+        self.state = "descending"
+        self.current_peak = smoothed
+        self.frames_in_state = 0
+        self.rep_start_frame = frame_idx
+        self.ascent_valley = smoothed
+        self.rep_max_torso_2d = signal_data.get("torso_2d_angle", 0)
+        self.rep_max_torso_3d = signal_data.get("torso_3d_angle", 0)
+        self.rep_min_knee = signal_data.get("knee_angle", 170)
+        self.rep_max_knee = signal_data.get("knee_angle", 170)
+        self.rep_back_issue = False
+        self.rep_back_angle = 0.0
+
+    def _normalized_peak(self):
+        return (self.current_peak - self.dynamic_floor) / max(0.20, self.dynamic_ceil - self.dynamic_floor)
+
+    def _build_rep_info(self):
+        return {
+            "rep": self.count,
+            "peak_signal": self.current_peak,
+            "good_depth": self.current_peak >= self.GOOD_DEPTH_PEAK,
+            "max_torso_2d": self.rep_max_torso_2d,
+            "max_torso_3d": self.rep_max_torso_3d,
+            "min_knee": self.rep_min_knee,
+            "max_knee": self.rep_max_knee,
+            "back_issue": self.rep_back_issue,
+            "back_angle": self.rep_back_angle,
+        }
+
+    def _reset_to_standing(self):
+        self.state = "standing"
+        self.frames_in_state = 0
+        self.current_peak = 0.0
+        self.rep_start_frame = -1
+        self.ascent_valley = 1.0
+
+    def finalize_pending_rep(self, frame_idx):
+        """
+        Count a likely last rep when video ends mid-ascent.
+        Useful when the last lockout is cut off by the clip ending.
+        """
+        if self.state != "ascending":
+            return None
+
+        valley_drop = self.current_peak - self.ascent_valley
+        normalized_drop = valley_drop / max(0.20, self.dynamic_ceil - self.dynamic_floor)
+        is_valid_peak = (self.current_peak >= self.MIN_PEAK_FOR_REP) or (self._normalized_peak() >= self.NORMALIZED_PEAK_THRESHOLD)
+        has_return = (valley_drop >= self.MIN_RETURN_FROM_PEAK * 0.7) or (normalized_drop >= self.NORMALIZED_DROP_THRESHOLD * 0.8)
+
+        if is_valid_peak and has_return and (frame_idx - self.last_rep_frame) >= self.MIN_FRAMES_BETWEEN:
+            self.count += 1
+            self.last_rep_frame = frame_idx
+            rep_info = self._build_rep_info()
+            self._reset_to_standing()
+            return rep_info
+
+        return None
 
     def update(self, signal_data, frame_idx):
         """
@@ -455,6 +537,7 @@ class RepCounter:
         raw = signal_data["composite"]
         self._calibrate(raw)
         smoothed = self._smooth(raw)
+        normalized = self._normalize_by_session_range(smoothed)
         self.frames_in_state += 1
 
         # Track per-rep metrics regardless of state
@@ -466,70 +549,70 @@ class RepCounter:
             self.rep_max_knee = max(self.rep_max_knee, knee_ang)
 
         if self.state == "standing":
-            if smoothed >= self.ENTER_THRESHOLD:
-                self.state = "descending"
-                self.current_peak = smoothed
-                self.frames_in_state = 0
-                # Reset per-rep metrics
-                self.rep_max_torso_2d = signal_data.get("torso_2d_angle", 0)
-                self.rep_max_torso_3d = signal_data.get("torso_3d_angle", 0)
-                self.rep_min_knee = signal_data.get("knee_angle", 170)
-                self.rep_max_knee = signal_data.get("knee_angle", 170)
-                self.rep_back_issue = False
-                self.rep_back_angle = 0.0
+            normalized_enter = normalized >= 0.34
+            if smoothed >= self.ENTER_THRESHOLD or normalized_enter:
+                self._start_rep_tracking(signal_data, frame_idx, smoothed)
 
         elif self.state == "descending":
             if smoothed > self.current_peak:
                 self.current_peak = smoothed
-            # If signal starts dropping, we're now ascending
-            if smoothed < self.current_peak - 0.05 and self.frames_in_state >= 3:
+
+            # If signal starts dropping, we're now ascending.
+            if smoothed < self.current_peak - 0.015 and self.frames_in_state >= 2:
                 self.state = "ascending"
                 self.frames_in_state = 0
+                self.ascent_valley = smoothed
+
+            if self.rep_start_frame > 0 and (frame_idx - self.rep_start_frame) > self.MAX_REP_FRAMES:
+                self._reset_to_standing()
 
         elif self.state == "ascending":
-            if smoothed <= self.EXIT_THRESHOLD and (frame_idx - self.last_rep_frame) >= self.MIN_FRAMES_BETWEEN:
-                # Rep completed — check if peak was deep enough
-                if self.current_peak >= self.MIN_PEAK_FOR_REP:
+            self.ascent_valley = min(self.ascent_valley, smoothed)
+            normalized_exit = normalized <= 0.28
+
+            # Standard completion by returning near standing.
+            if (smoothed <= self.EXIT_THRESHOLD or normalized_exit) and (frame_idx - self.last_rep_frame) >= self.MIN_FRAMES_BETWEEN:
+                if self.current_peak >= self.MIN_PEAK_FOR_REP or self._normalized_peak() >= self.NORMALIZED_PEAK_THRESHOLD:
                     self.count += 1
                     self.last_rep_frame = frame_idx
-                    self.state = "standing"
-                    self.frames_in_state = 0
-
-                    rep_info = {
-                        "rep": self.count,
-                        "peak_signal": self.current_peak,
-                        "good_depth": self.current_peak >= self.GOOD_DEPTH_PEAK,
-                        "max_torso_2d": self.rep_max_torso_2d,
-                        "max_torso_3d": self.rep_max_torso_3d,
-                        "min_knee": self.rep_min_knee,
-                        "max_knee": self.rep_max_knee,
-                        "back_issue": self.rep_back_issue,
-                        "back_angle": self.rep_back_angle,
-                    }
-                    self.current_peak = 0.0
+                    rep_info = self._build_rep_info()
+                    self._reset_to_standing()
                     return rep_info
-                else:
-                    # Not deep enough — reset without counting
-                    self.state = "standing"
-                    self.frames_in_state = 0
-                    self.current_peak = 0.0
+                self._reset_to_standing()
 
-            # Handle case where person goes back down without fully standing
+            # Touch-and-go completion: ascent reverses before full exit.
+            valley_drop = self.current_peak - self.ascent_valley
+            if smoothed > (self.ascent_valley + self.REBOUND_DELTA) and self.frames_in_state >= 2:
+                normalized_drop = valley_drop / max(0.20, self.dynamic_ceil - self.dynamic_floor)
+                is_valid_peak = (self.current_peak >= self.MIN_PEAK_FOR_REP) or (self._normalized_peak() >= self.NORMALIZED_PEAK_THRESHOLD)
+                has_return = (valley_drop >= self.MIN_RETURN_FROM_PEAK) or (normalized_drop >= self.NORMALIZED_DROP_THRESHOLD)
+
+                if is_valid_peak and has_return and (frame_idx - self.last_rep_frame) >= self.MIN_FRAMES_BETWEEN:
+                    self.count += 1
+                    self.last_rep_frame = frame_idx
+                    rep_info = self._build_rep_info()
+                    self._start_rep_tracking(signal_data, frame_idx, smoothed)
+                    return rep_info
+
+            # Handle case where person goes much deeper again without clear valley.
             if smoothed > self.current_peak:
                 self.current_peak = smoothed
                 self.state = "descending"
                 self.frames_in_state = 0
+
+            if self.rep_start_frame > 0 and (frame_idx - self.rep_start_frame) > self.MAX_REP_FRAMES:
+                self._reset_to_standing()
 
         return None
 
 
 # ===================== PARAMETERS =====================
 HINGE_BOTTOM_ANGLE = 55.0  # For depth quality check
-KNEE_MIN_ANGLE = 155.0
+KNEE_MIN_ANGLE = 168.0
 KNEE_OPTIMAL_MIN = 160.0
 KNEE_OPTIMAL_MAX = 170.0
-KNEE_MAX_ANGLE = 140.0
-BACK_MAX_ANGLE = 45.0
+KNEE_MAX_ANGLE = 125.0
+BACK_MAX_ANGLE = 60.0
 
 MIN_SCORE = 4.0
 MAX_SCORE = 10.0
@@ -713,7 +796,7 @@ def run_romanian_deadlift_analysis(video_path,
                     score -= 2.0
 
                 # Back check
-                if rep_result["back_issue"] and rep_result["back_angle"] > BACK_MAX_ANGLE:
+                if rep_result["back_issue"] and rep_result["back_angle"] > (BACK_MAX_ANGLE + 5.0):
                     feedback.append("Try to keep your back neutral")
                     score -= 1.0
 
@@ -765,6 +848,55 @@ def run_romanian_deadlift_analysis(video_path,
                                            depth_pct=prog)
                 out.write(frame_drawn)
 
+    # Finalize likely last rep if video ended mid-lockout
+    rep_result = rep_counter.finalize_pending_rep(frame_idx)
+    if rep_result is not None:
+        feedback = []
+        score = MAX_SCORE
+
+        best_torso = max(rep_result["max_torso_2d"], rep_result["max_torso_3d"])
+        if not rep_result["good_depth"] and best_torso < HINGE_BOTTOM_ANGLE:
+            feedback.append("Go deeper - hinge more at the hips")
+            score -= 2.0
+
+        if rep_result["max_knee"] > KNEE_MIN_ANGLE:
+            feedback.append("Bend your knees a bit more")
+            score -= 1.5
+        elif rep_result["min_knee"] < KNEE_MAX_ANGLE:
+            feedback.append("Too much knee bend")
+            score -= 2.0
+
+        if rep_result["back_issue"] and rep_result["back_angle"] > (BACK_MAX_ANGLE + 5.0):
+            feedback.append("Try to keep your back neutral")
+            score -= 1.0
+
+        score = float(max(MIN_SCORE, min(MAX_SCORE, score)))
+        all_scores.append(score)
+        if score >= 9.0:
+            good_reps += 1
+        else:
+            bad_reps += 1
+
+        session_feedbacks.extend(feedback)
+        _, session_feedback_by_cat = pick_strongest_per_category(session_feedbacks)
+
+        rep_reports.append({
+            "rep": rep_result["rep"],
+            "score": round(score, 2),
+            "score_display": display_half_str(score),
+            "label": score_label(score),
+            "feedback": feedback,
+            "metrics": {
+                "peak_signal": round(rep_result["peak_signal"], 3),
+                "max_torso_2d_angle": round(rep_result["max_torso_2d"], 2),
+                "max_torso_3d_angle": round(rep_result["max_torso_3d"], 2),
+                "min_knee_angle": round(rep_result["min_knee"], 2),
+                "max_knee_angle": round(rep_result["max_knee"], 2),
+                "back_angle": round(rep_result["back_angle"], 2),
+                "view_type": "end_of_clip",
+            }
+        })
+
     cap.release()
     if out:
         out.release()
@@ -780,7 +912,7 @@ def run_romanian_deadlift_analysis(video_path,
     if session_feedbacks and len(session_feedbacks) > 0:
         technique_score = min(technique_score, 9.5)
 
-    feedback_list = dedupe_feedback(session_feedbacks) if session_feedbacks else ["Perfect form! 🔥"]
+    feedback_list = dedupe_feedback(list(session_feedback_by_cat.values())) if session_feedback_by_cat else (["Perfect form! 🔥"] if not session_feedbacks else dedupe_feedback(session_feedbacks))
 
     session_tip = None
     if session_feedback_by_cat:


### PR DESCRIPTION
### Motivation
- Address missed short/touch-and-go reps (e.g. 3rd rep often not counted) and cases where video ends mid-ascent caused undercounting. 
- Reduce contradictory or noisy session feedback about knees/back that made the summary confusing. 
- Make thresholds more robust to compressed signals caused by camera angle or shallow movements shown in supplied frames. 

### Description
- Increased rep sensitivity and resilience by lowering `MIN_FRAMES_BETWEEN` to `4`, reducing `MIN_RETURN_FROM_PEAK` to `0.04`, and setting `NORMALIZED_DROP_THRESHOLD` to `0.10`, and adding `MAX_REP_FRAMES` and `REBOUND_DELTA` to improve touch-and-go detection. 
- Added session-normalization and per-rep helpers: `def _normalize_by_session_range`, `_start_rep_tracking`, `_normalized_peak`, `_build_rep_info`, `_reset_to_standing`, plus a new `finalize_pending_rep(frame_idx)` to count a likely final rep when the clip ends mid-ascent. 
- Made descending→ascending transition more permissive (`0.015` drop with >=2 frames) and used normalized enter/exit checks so shallow/compressed signals still trigger. 
- Tuned quality thresholds to reduce false/conflicting cues by changing `KNEE_MIN_ANGLE = 168.0`, `KNEE_MAX_ANGLE = 125.0`, `BACK_MAX_ANGLE = 60.0`, and tightened the back warning to require `> (BACK_MAX_ANGLE + 5.0)`. 
- Reduced contradictory session feedback by preferring the strongest cue per category when building `feedback_list`, and appended end-of-clip rep metrics (`"view_type": "end_of_clip"`) when `finalize_pending_rep` produces a rep. 

### Testing
- Ran `python -m py_compile romanian_deadlift_analysis.py` and compilation succeeded. 
- Static inspection and small runtime traces were used to validate the new `RepCounter` flow (no failing automated tests introduced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de9709388832397568304ec618906)