### PR TITLE
Improve pushup form detection with confirmed bottom samples

### DIFF
--- a/pushup_analysis.py
+++ b/pushup_analysis.py
@@ -524,7 +524,7 @@ def run_pushup_analysis(video_path,
                 motion_detector.activate("enter_plank")
 
             if onpushup and offpushup_streak>=OFFPUSHUP_MIN_FRAMES:
-                robust_bottom_elbow, robust_top_elbow = _robust_cycle_elbows(cycle_bottom_samples, cycle_top_samples, bottom_phase_min_elbow, top_phase_max_elbow)
+                robust_bottom_elbow, robust_top_elbow = _robust_cycle_elbows(cycle_bottom_samples, cycle_top_samples, bottom_phase_min_elbow, top_phase_max_elbow, confirmed_bottom=confirmed_bottom_samples)
                 cycle_has_issues = _evaluate_cycle_form(lms, robust_bottom_elbow, robust_top_elbow,
                                    cycle_max_hip_misalign, cycle_max_flare,
                                    cycle_max_descent_vel,
@@ -621,7 +621,8 @@ def run_pushup_analysis(video_path,
                     
                     if reset_by_asc or reset_by_elb:
                         robust_bottom_elbow, robust_top_elbow = _robust_cycle_elbows(
-                            cycle_bottom_samples, cycle_top_samples, bottom_phase_min_elbow, top_phase_max_elbow
+                            cycle_bottom_samples, cycle_top_samples, bottom_phase_min_elbow, top_phase_max_elbow,
+                            confirmed_bottom=confirmed_bottom_samples
                         )
                         cycle_has_issues = _evaluate_cycle_form(lms, robust_bottom_elbow, robust_top_elbow,
                                            cycle_max_hip_misalign, cycle_max_flare,
@@ -728,7 +729,7 @@ def run_pushup_analysis(video_path,
             if shoulder_y is not None: shoulder_prev=shoulder_y
 
     if onpushup and (not counted_this_cycle) and (cycle_max_descent>=SHOULDER_MIN_DESCENT) and (cycle_min_elbow<=ELBOW_BENT_ANGLE):
-        robust_bottom_elbow, robust_top_elbow = _robust_cycle_elbows(cycle_bottom_samples, cycle_top_samples, bottom_phase_min_elbow, top_phase_max_elbow)
+        robust_bottom_elbow, robust_top_elbow = _robust_cycle_elbows(cycle_bottom_samples, cycle_top_samples, bottom_phase_min_elbow, top_phase_max_elbow, confirmed_bottom=confirmed_bottom_samples)
         cycle_has_issues = _evaluate_cycle_form(lms, robust_bottom_elbow, robust_top_elbow,
                            cycle_max_hip_misalign, cycle_max_flare,
                            cycle_max_descent_vel,
@@ -855,12 +856,18 @@ def _robust_cycle_elbows(bottom_samples, top_samples, fallback_bottom=None, fall
     # was detected at the bottom position, so the percentile is not inflated by
     # mid-descent angles. This prevents false "go deeper" feedback when the user
     # is genuinely touching the floor.
-    if confirmed_bottom and len(confirmed_bottom) >= 2:
+    if confirmed_bottom and len(confirmed_bottom) >= 1:
         arr = np.array(confirmed_bottom, dtype=np.float32)
         robust_bottom = float(np.percentile(arr, ROBUST_CONFIRMED_PERCENTILE))
     elif bottom_samples:
         arr = np.array(bottom_samples, dtype=np.float32)
         robust_bottom = float(np.percentile(arr, ROBUST_BOTTOM_PERCENTILE))
+
+    # Cap the robust estimate with the actual observed minimum angle.
+    # The percentile of all-cycle samples can be inflated by descent/ascent frames;
+    # if the person genuinely reached a deep position, trust that observation.
+    if fallback_bottom is not None and robust_bottom is not None:
+        robust_bottom = min(robust_bottom, fallback_bottom)
 
     if top_samples:
         arr = np.array(top_samples, dtype=np.float32)


### PR DESCRIPTION
## Summary
This PR enhances the pushup cycle analysis by incorporating confirmed bottom position samples into the robust elbow angle calculations, and adds a safeguard to prevent inflated depth estimates.

## Key Changes
- **Pass confirmed bottom samples to `_robust_cycle_elbows()`**: Updated three call sites (lines 527, 624-625, and 731) to pass `confirmed_bottom=confirmed_bottom_samples` parameter, enabling the function to use verified bottom position data for more accurate angle estimation.

- **Relax confirmed bottom sample threshold**: Changed the minimum required confirmed bottom samples from 2 to 1 (line 859), allowing the function to use confirmed data even when only a single verified bottom position is available.

- **Add fallback bottom capping logic**: Introduced a new safeguard (lines 868-871) that caps the percentile-based robust bottom estimate with the actual observed minimum angle. This prevents the percentile calculation from being inflated by descent/ascent frames and ensures that genuinely deep positions are properly recognized.

## Implementation Details
The changes work together to improve form detection accuracy:
1. Confirmed bottom samples (positions where the user actually reached the bottom) are now prioritized in the robust angle calculation
2. The percentile-based estimate is now bounded by the actual minimum observed angle, preventing false "go deeper" feedback when users legitimately touch the floor
3. The lower threshold for confirmed samples allows the improved logic to activate more frequently

https://claude.ai/code/session_01PzaEi7zjWqkACbF9aAANjj