### PR TITLE
Add non-scoring form tips for overhead press coaching

### DIFF
--- a/overhead_press_analysis.py
+++ b/overhead_press_analysis.py
@@ -186,6 +186,52 @@ def score_label(s: float) -> str:
     return "Poor"
 
 
+# ============ Form Tips (non-scoring, coaching suggestions) ============
+# These do NOT affect the score — they are general coaching observations.
+
+PRESS_TIP_SLOW_DESCENT  = "Lower the bar slowly — aim for 2–3 seconds on the way down"
+PRESS_TIP_PAUSE_BOTTOM  = "Pause briefly at the shoulder before pressing for better activation"
+PRESS_TIP_BAR_PATH      = "Focus on pressing straight up — keep the bar path vertical"
+PRESS_TIP_BREATHE       = "Breathe in on the way down, breathe out as you press"
+PRESS_TIP_KEEP_GOING    = "Great consistency — keep challenging yourself!"
+
+# Priority order for tip selection
+PRESS_TIP_PRIORITY = [
+    PRESS_TIP_SLOW_DESCENT,
+    PRESS_TIP_PAUSE_BOTTOM,
+    PRESS_TIP_BAR_PATH,
+    PRESS_TIP_BREATHE,
+    PRESS_TIP_KEEP_GOING,
+]
+
+# Thresholds for tip selection
+TIP_MIN_DESC_FRAMES  = 6     # Descent shorter than this → suggest slower eccentric
+TIP_DESC_ASC_RATIO   = 0.65  # Descent/ascent ratio below this → suggest slower eccentric
+TIP_BAR_PATH_WARN    = 0.045 # Bar path deviation above this (but below score threshold) → path tip
+
+
+def choose_press_tip(avg_desc_frames: float, avg_asc_frames: float, avg_bar_path_dev: float) -> str:
+    """
+    Return a coaching form tip (non-scoring) for military press.
+
+    avg_desc_frames   – average descending-phase frames per rep
+    avg_asc_frames    – average ascending-phase frames per rep
+    avg_bar_path_dev  – average bar-path lateral deviation (normalised)
+    """
+    # Eccentric too fast → slow down tip
+    if avg_desc_frames < TIP_MIN_DESC_FRAMES:
+        return PRESS_TIP_SLOW_DESCENT
+    if avg_asc_frames > 0 and (avg_desc_frames / avg_asc_frames) < TIP_DESC_ASC_RATIO:
+        return PRESS_TIP_SLOW_DESCENT
+
+    # Moderate bar-path wobble (not bad enough to fail, but worth coaching)
+    if avg_bar_path_dev > TIP_BAR_PATH_WARN:
+        return PRESS_TIP_BAR_PATH
+
+    # Default breathing/technique cue
+    return PRESS_TIP_BREATHE
+
+
 # ============ Torso Lean Calculation ============
 
 def compute_torso_lean(lms, lsh, rsh, lh, rh, vis_thr: float = 0.3) -> Optional[float]:
@@ -805,7 +851,12 @@ class OverheadPressTracker:
                 "issues": r.issues,
             })
 
-        form_tip = session_feedback[0] if session_feedback else None
+        # Form tip — coaching note that does NOT affect the score.
+        # Chosen from descending-phase tempo and bar-path data, independent of feedback.
+        avg_desc  = float(np.mean([r.descending_frames for r in self.all_reps]))
+        avg_asc   = float(np.mean([r.ascending_frames  for r in self.all_reps]))
+        avg_bar_dev = float(np.mean([r.bar_path_deviation for r in self.all_reps]))
+        form_tip  = choose_press_tip(avg_desc, avg_asc, avg_bar_dev)
 
         return {
             "rep_count": self.rep_count,


### PR DESCRIPTION
## Summary
This PR introduces a new form-tip system for the overhead press analysis that provides coaching suggestions independent of the scoring mechanism. Form tips are now generated based on eccentric tempo and bar-path metrics, offering athletes actionable feedback without affecting their performance score.

## Key Changes
- **New form tip constants**: Added five coaching suggestions covering eccentric tempo, pause timing, bar path, breathing, and consistency
- **Tip selection logic**: Implemented `choose_press_tip()` function that intelligently selects the most relevant coaching cue based on:
  - Eccentric phase duration (flags if descent is too fast)
  - Descent-to-ascent ratio (ensures controlled lowering)
  - Bar-path lateral deviation (detects wobble in pressing pattern)
- **Priority-based system**: Tips are evaluated in priority order, with eccentric tempo issues taking precedence over bar-path concerns
- **Session summary integration**: Modified `get_session_summary()` to compute form tips from rep-level metrics (descending frames, ascending frames, bar path deviation) rather than relying on feedback-based scoring

## Implementation Details
- Form tips are completely decoupled from the scoring system and do NOT affect rep or session scores
- Configurable thresholds allow easy tuning of tip triggers:
  - `TIP_MIN_DESC_FRAMES = 6` frames minimum for eccentric phase
  - `TIP_DESC_ASC_RATIO = 0.65` minimum ratio of descent to ascent duration
  - `TIP_BAR_PATH_WARN = 0.045` normalized deviation threshold for bar-path coaching
- Default tip provides general breathing/technique guidance when no specific issues are detected

https://claude.ai/code/session_016rwNM7rbzBgcpTCnxQH3fi