### PR TITLE
Render overlays on 1080p canvas and downscale for crisp UI

### DIFF
--- a/bent_over_row_analysis.py
+++ b/bent_over_row_analysis.py
@@ -227,42 +227,50 @@ def _wrap_two_lines(draw, text, font, max_width):
 def draw_overlay(frame, reps=0, feedback=None, depth_pct=0.0):
     """Reps top-left; donut top-right; feedback bottom — matches pullup/good morning exactly."""
     h, w, _ = frame.shape
+    HD_H = 1080
+    hd_scale = HD_H / float(h)
+    HD_W = max(1, int(round(w * hd_scale)))
 
-    # Scale all font sizes proportionally to frame height
-    reps_font_size = _scaled_font_size(_REF_REPS_FONT_SIZE, h)
-    feedback_font_size = _scaled_font_size(_REF_FEEDBACK_FONT_SIZE, h)
-    depth_label_font_size = _scaled_font_size(_REF_DEPTH_LABEL_FONT_SIZE, h)
-    depth_pct_font_size = _scaled_font_size(_REF_DEPTH_PCT_FONT_SIZE, h)
+    reps_font_size = _scaled_font_size(_REF_REPS_FONT_SIZE, HD_H)
+    feedback_font_size = _scaled_font_size(_REF_FEEDBACK_FONT_SIZE, HD_H)
+    depth_label_font_size = _scaled_font_size(_REF_DEPTH_LABEL_FONT_SIZE, HD_H)
+    depth_pct_font_size = _scaled_font_size(_REF_DEPTH_PCT_FONT_SIZE, HD_H)
 
     _REPS_FONT = _load_font(FONT_PATH, reps_font_size)
     _FEEDBACK_FONT = _load_font(FONT_PATH, feedback_font_size)
     _DEPTH_LABEL_FONT = _load_font(FONT_PATH, depth_label_font_size)
     _DEPTH_PCT_FONT = _load_font(FONT_PATH, depth_pct_font_size)
 
-    ref_h = max(int(h * 0.06), int(reps_font_size * 1.6))
+    pct = float(np.clip(depth_pct, 0, 1))
+    ref_h = max(int(HD_H * 0.06), int(reps_font_size * 1.6))
     r = int(ref_h * DONUT_RADIUS_SCALE)
     th = max(3, int(r * DONUT_THICKNESS_FRAC))
     m = 12
-    cx = w - m - r
+    cx = HD_W - m - r
     cy = max(ref_h + r // 8, r + th // 2 + 2)
-    pct = float(np.clip(depth_pct, 0, 1))
-    cv2.circle(frame, (cx, cy), r, DEPTH_RING_BG, th, cv2.LINE_AA)
-    cv2.ellipse(frame, (cx, cy), (r, r), 0, -90, -90 + int(360 * pct), DEPTH_COLOR, th, cv2.LINE_AA)
 
-    pil = Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
-    draw = ImageDraw.Draw(pil)
+    overlay_bgr = np.zeros((HD_H, HD_W, 3), dtype=np.uint8)
+    overlay_a = np.zeros((HD_H, HD_W), dtype=np.uint8)
+    bg_alpha = int(round(255 * BAR_BG_ALPHA))
 
     txt = f"Reps: {int(reps)}"
     pad_x, pad_y = 10, 6
-    tw = draw.textlength(txt, font=_REPS_FONT)
+    tmp = ImageDraw.Draw(Image.new("RGBA", (1, 1)))
+    tw = tmp.textlength(txt, font=_REPS_FONT)
     thh = _REPS_FONT.size
-    base = np.array(pil)
-    over = base.copy()
-    cv2.rectangle(over, (0, 0), (int(tw + 2 * pad_x), int(thh + 2 * pad_y)), (0, 0, 0), -1)
-    base = cv2.addWeighted(over, BAR_BG_ALPHA, base, 1 - BAR_BG_ALPHA, 0)
-    pil = Image.fromarray(base)
+    cv2.rectangle(overlay_bgr, (0, 0), (int(tw + 2 * pad_x), int(thh + 2 * pad_y)), (0, 0, 0), -1)
+    cv2.rectangle(overlay_a, (0, 0), (int(tw + 2 * pad_x), int(thh + 2 * pad_y)), bg_alpha, -1)
+
+    cv2.circle(overlay_bgr, (cx, cy), r, DEPTH_RING_BG, th, cv2.LINE_AA)
+    cv2.circle(overlay_a, (cx, cy), r, 255, th, cv2.LINE_AA)
+    cv2.ellipse(overlay_bgr, (cx, cy), (r, r), 0, -90, -90 + int(360 * pct), DEPTH_COLOR, th, cv2.LINE_AA)
+    cv2.ellipse(overlay_a, (cx, cy), (r, r), 0, -90, -90 + int(360 * pct), 255, th, cv2.LINE_AA)
+
+    pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+    pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+    pil = Image.fromarray(pil_rgba)
     draw = ImageDraw.Draw(pil)
-    draw.text((pad_x, pad_y - 1), txt, font=_REPS_FONT, fill=(255, 255, 255))
+    draw.text((pad_x, pad_y - 1), txt, font=_REPS_FONT, fill=(255, 255, 255, 255))
 
     gap = max(2, int(r * 0.10))
     by = cy - (_DEPTH_LABEL_FONT.size + gap + _DEPTH_PCT_FONT.size) // 2
@@ -270,30 +278,36 @@ def draw_overlay(frame, reps=0, feedback=None, depth_pct=0.0):
     pct_txt = f"{int(pct * 100)}%"
     lw = draw.textlength(label, font=_DEPTH_LABEL_FONT)
     pw = draw.textlength(pct_txt, font=_DEPTH_PCT_FONT)
-    draw.text((cx - int(lw // 2), by), label, font=_DEPTH_LABEL_FONT, fill=(255, 255, 255))
-    draw.text((cx - int(pw // 2), by + _DEPTH_LABEL_FONT.size + gap), pct_txt, font=_DEPTH_PCT_FONT, fill=(255, 255, 255))
+    draw.text((cx - int(lw // 2), by), label, font=_DEPTH_LABEL_FONT, fill=(255, 255, 255, 255))
+    draw.text((cx - int(pw // 2), by + _DEPTH_LABEL_FONT.size + gap), pct_txt, font=_DEPTH_PCT_FONT, fill=(255, 255, 255, 255))
 
     if feedback:
-        max_w = int(w - 2 * 12 - 20)
+        max_w = int(HD_W - 2 * 12 - 20)
         lines = _wrap_two_lines(draw, feedback, _FEEDBACK_FONT, max_w)
         line_h = _FEEDBACK_FONT.size + 6
         block_h = 2 * 8 + len(lines) * line_h + (len(lines) - 1) * 4
-        y0 = max(0, h - max(6, int(h * 0.02)) - block_h)
-        y1 = h - max(6, int(h * 0.02))
-        base2 = np.array(pil)
-        over2 = base2.copy()
-        cv2.rectangle(over2, (0, y0), (w, y1), (0, 0, 0), -1)
-        base2 = cv2.addWeighted(over2, BAR_BG_ALPHA, base2, 1 - BAR_BG_ALPHA, 0)
-        pil = Image.fromarray(base2)
+        y0 = max(0, HD_H - max(6, int(HD_H * 0.02)) - block_h)
+        y1 = HD_H - max(6, int(HD_H * 0.02))
+        cv2.rectangle(overlay_bgr, (0, y0), (HD_W, y1), (0, 0, 0), -1)
+        cv2.rectangle(overlay_a, (0, y0), (HD_W, y1), bg_alpha, -1)
+
+        pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+        pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+        pil = Image.fromarray(pil_rgba)
         draw = ImageDraw.Draw(pil)
         ty = y0 + 8
         for ln in lines:
             tw2 = draw.textlength(ln, font=_FEEDBACK_FONT)
-            tx = max(12, (w - int(tw2)) // 2)
-            draw.text((tx, ty), ln, font=_FEEDBACK_FONT, fill=(255, 255, 255))
+            tx = max(12, (HD_W - int(tw2)) // 2)
+            draw.text((tx, ty), ln, font=_FEEDBACK_FONT, fill=(255, 255, 255, 255))
             ty += line_h + 4
 
-    return cv2.cvtColor(np.array(pil), cv2.COLOR_RGB2BGR)
+    overlay_rgba = np.array(pil)
+    overlay_small = cv2.resize(overlay_rgba, (w, h), interpolation=cv2.INTER_AREA)
+    alpha = overlay_small[:, :, 3:4].astype(np.float32) / 255.0
+    rgb = cv2.cvtColor(overlay_small[:, :, :3], cv2.COLOR_RGB2BGR).astype(np.float32)
+    out = frame.astype(np.float32) * (1.0 - alpha) + rgb * alpha
+    return out.astype(np.uint8)
 
 # ================== CORE ANALYSIS ==================
 def get_landmarks_xy(results, frame_shape):

--- a/bulgarian_split_squat_analysis.py
+++ b/bulgarian_split_squat_analysis.py
@@ -241,60 +241,108 @@ def _wrap_two_lines(draw, text, font, max_width):
 
 
 def draw_overlay(frame, reps=0, feedback=None, depth_pct=0.0):
+    """Reps בפינת שמאל-עליון; דונאט ימני-עליון; פידבק תחתון"""
     h, w, _ = frame.shape
-    depth_pct = float(np.clip(depth_pct, 0.0, 1.0))
+    HD_H = 1080
+    hd_scale = HD_H / float(h)
+    HD_W = max(1, int(round(w * hd_scale)))
 
-    # Reps box (top-left)
-    pil = Image.fromarray(frame); draw = ImageDraw.Draw(pil)
-    reps_text = f"Reps: {reps}"
-    px, py = 10, 6
-    tw = draw.textlength(reps_text, font=REPS_FONT)
-    x1 = int(tw + 2*px); y1 = int(REPS_FONT_SIZE + 2*py)
-    top = frame.copy(); cv2.rectangle(top, (0,0), (x1,y1), (0,0,0), -1)
-    frame = cv2.addWeighted(top, BAR_BG_ALPHA, frame, 1.0-BAR_BG_ALPHA, 0)
-    pil = Image.fromarray(frame)
-    ImageDraw.Draw(pil).text((px, py-1), reps_text, font=REPS_FONT, fill=(255,255,255))
-    frame = np.array(pil)
-
-    # Depth donut (top-right)
-    ref_h = max(int(h*0.06), int(REPS_FONT_SIZE*1.6))
+    pct = float(np.clip(depth_pct, 0, 1))
+    ref_h = max(int(HD_H * 0.06), int(REPS_FONT_SIZE * 1.6))
     radius = int(ref_h * DONUT_RADIUS_SCALE)
     thick = max(3, int(radius * DONUT_THICKNESS_FRAC))
-    cx = w - 12 - radius
-    cy = max(ref_h + radius//8, radius + thick//2 + 2)
-    cv2.circle(frame, (cx,cy), radius, DEPTH_RING_BG, thick, cv2.LINE_AA)
-    cv2.ellipse(frame, (cx,cy), (radius,radius), 0, -90, -90+int(360*depth_pct),
-                DEPTH_COLOR, thick, cv2.LINE_AA)
-    pil = Image.fromarray(frame); draw = ImageDraw.Draw(pil)
-    lt = "DEPTH"; pt = f"{int(depth_pct*100)}%"
-    lw = draw.textlength(lt, font=DEPTH_LABEL_FONT)
-    pw = draw.textlength(pt, font=DEPTH_PCT_FONT)
-    gap = max(2, int(radius*0.10))
-    by = cy - (DEPTH_LABEL_FONT_SIZE + gap + DEPTH_PCT_FONT_SIZE)//2
-    draw.text((cx-int(lw//2), by), lt, font=DEPTH_LABEL_FONT, fill=(255,255,255))
-    draw.text((cx-int(pw//2), by+DEPTH_LABEL_FONT_SIZE+gap), pt, font=DEPTH_PCT_FONT, fill=(255,255,255))
-    frame = np.array(pil)
+    margin = 12
+    cx = HD_W - margin - radius
+    cy = max(ref_h + radius // 8, radius + thick // 2 + 2)
 
-    # Feedback bar (bottom)
+    overlay_bgr = np.zeros((HD_H, HD_W, 3), dtype=np.uint8)
+    overlay_a = np.zeros((HD_H, HD_W), dtype=np.uint8)
+    bg_alpha = int(round(255 * BAR_BG_ALPHA))
+
+    reps_text = f"Reps: {reps}"
+    inner_pad_x, inner_pad_y = 10, 6
+    tmp = ImageDraw.Draw(Image.new("RGBA", (1, 1)))
+    text_w = tmp.textlength(reps_text, font=REPS_FONT)
+    text_h = REPS_FONT.size
+    cv2.rectangle(overlay_bgr, (0, 0), (int(text_w + 2 * inner_pad_x), int(text_h + 2 * inner_pad_y)), (0, 0, 0), -1)
+    cv2.rectangle(overlay_a, (0, 0), (int(text_w + 2 * inner_pad_x), int(text_h + 2 * inner_pad_y)), bg_alpha, -1)
+
+    cv2.circle(overlay_bgr, (cx, cy), radius, DEPTH_RING_BG, thick, cv2.LINE_AA)
+    cv2.circle(overlay_a, (cx, cy), radius, 255, thick, cv2.LINE_AA)
+    start_ang = -90
+    end_ang = start_ang + int(360 * pct)
+    cv2.ellipse(overlay_bgr, (cx, cy), (radius, radius), 0, start_ang, end_ang, DEPTH_COLOR, thick, lineType=cv2.LINE_AA)
+    cv2.ellipse(overlay_a, (cx, cy), (radius, radius), 0, start_ang, end_ang, 255, thick, lineType=cv2.LINE_AA)
+
+    pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+    pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+    pil = Image.fromarray(pil_rgba)
+    draw = ImageDraw.Draw(pil)
+    draw.text((inner_pad_x, inner_pad_y - 1), reps_text, font=REPS_FONT, fill=(255, 255, 255, 255))
+
+    label_txt = "DEPTH"
+    pct_txt = f"{int(pct * 100)}%"
+    label_w = draw.textlength(label_txt, font=DEPTH_LABEL_FONT)
+    pct_w = draw.textlength(pct_txt, font=DEPTH_PCT_FONT)
+    gap = max(2, int(radius * 0.10))
+    base_y = cy - (DEPTH_LABEL_FONT.size + gap + DEPTH_PCT_FONT.size) // 2
+    draw.text((cx - int(label_w // 2), base_y), label_txt, font=DEPTH_LABEL_FONT, fill=(255, 255, 255, 255))
+    draw.text((cx - int(pct_w // 2), base_y + DEPTH_LABEL_FONT.size + gap), pct_txt, font=DEPTH_PCT_FONT, fill=(255, 255, 255, 255))
+
     if feedback:
-        pil_fb = Image.fromarray(frame); draw_fb = ImageDraw.Draw(pil_fb)
-        safe = max(6, int(h*0.02))
-        max_tw = int(w - 44)
-        lines = _wrap_two_lines(draw_fb, feedback, FEEDBACK_FONT, max_tw)
-        lh = FEEDBACK_FONT_SIZE + 6
-        bh = 16 + len(lines)*lh + (len(lines)-1)*4
-        y0 = max(0, h - safe - bh)
-        over = frame.copy(); cv2.rectangle(over, (0,y0), (w,h-safe), (0,0,0), -1)
-        frame = cv2.addWeighted(over, BAR_BG_ALPHA, frame, 1.0-BAR_BG_ALPHA, 0)
-        pil_fb = Image.fromarray(frame); draw_fb = ImageDraw.Draw(pil_fb)
-        ty = y0 + 8
-        for ln in lines:
-            tww = draw_fb.textlength(ln, font=FEEDBACK_FONT)
-            draw_fb.text((max(12, (w-int(tww))//2), ty), ln, font=FEEDBACK_FONT, fill=(255,255,255))
-            ty += lh + 4
-        frame = np.array(pil_fb)
-    return frame
+        def _wrap_two_lines(draw_obj, text, font, max_width):
+            words = text.split()
+            if not words:
+                return [""]
+            lines, cur = [], ""
+            for word in words:
+                trial = (cur + " " + word).strip()
+                if draw_obj.textlength(trial, font=font) <= max_width:
+                    cur = trial
+                else:
+                    if cur:
+                        lines.append(cur)
+                    cur = word
+                if len(lines) == 2:
+                    break
+            if cur and len(lines) < 2:
+                lines.append(cur)
+            leftover = len(words) - sum(len(line.split()) for line in lines)
+            if leftover > 0 and len(lines) >= 2:
+                last = lines[-1] + "…"
+                while draw_obj.textlength(last, font=font) > max_width and len(last) > 1:
+                    last = last[:-2] + "…"
+                lines[-1] = last
+            return lines
 
+        safe_margin = max(6, int(HD_H * 0.02))
+        pad_x, pad_y, line_gap = 12, 8, 4
+        max_text_w = int(HD_W - 2 * pad_x - 20)
+        lines = wrap_to_two_lines(draw, feedback, FEEDBACK_FONT, max_text_w)
+        line_h = FEEDBACK_FONT.size + 6
+        block_h = (2 * pad_y) + len(lines) * line_h + (len(lines) - 1) * line_gap
+        y0 = max(0, HD_H - safe_margin - block_h)
+        y1 = HD_H - safe_margin
+        cv2.rectangle(overlay_bgr, (0, y0), (HD_W, y1), (0, 0, 0), -1)
+        cv2.rectangle(overlay_a, (0, y0), (HD_W, y1), bg_alpha, -1)
+
+        pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+        pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+        pil = Image.fromarray(pil_rgba)
+        draw = ImageDraw.Draw(pil)
+        ty = y0 + pad_y
+        for ln in lines:
+            tw = draw.textlength(ln, font=FEEDBACK_FONT)
+            tx = max(pad_x, (HD_W - int(tw)) // 2)
+            draw.text((tx, ty), ln, font=FEEDBACK_FONT, fill=(255, 255, 255, 255))
+            ty += line_h + line_gap
+
+    overlay_rgba = np.array(pil)
+    overlay_small = cv2.resize(overlay_rgba, (w, h), interpolation=cv2.INTER_AREA)
+    alpha = overlay_small[:, :, 3:4].astype(np.float32) / 255.0
+    rgb = cv2.cvtColor(overlay_small[:, :, :3], cv2.COLOR_RGB2BGR).astype(np.float32)
+    out = frame.astype(np.float32) * (1.0 - alpha) + rgb * alpha
+    return out.astype(np.uint8)
 
 # ========================== REP COUNTER ==========================
 

--- a/deadlift_analysis.py
+++ b/deadlift_analysis.py
@@ -355,49 +355,79 @@ def _donut(frame, c, r, t, p):
 
 def draw_overlay(frame, reps=0, feedback=None, progress_pct=0.0):
     h, w, _ = frame.shape
-    # Reps box
-    pil = Image.fromarray(frame); d = ImageDraw.Draw(pil)
-    txt = f"Reps: {reps}"; padx, pady = 10, 6
-    tw = d.textlength(txt, font=REPS_FONT); th = REPS_FONT.size
-    x0, y0 = 0, 0; x1 = int(tw + 2*padx); y1 = int(th + 2*pady)
-    top = frame.copy(); cv2.rectangle(top, (x0,y0), (x1,y1), (0,0,0), -1)
-    frame = cv2.addWeighted(top, BAR_BG_ALPHA, frame, 1-BAR_BG_ALPHA, 0)
-    pil = Image.fromarray(frame)
-    ImageDraw.Draw(pil).text((x0+padx, y0+pady-1), txt, font=REPS_FONT, fill=(255,255,255))
-    frame = np.array(pil)
+    HD_H = 1080
+    hd_scale = HD_H / float(h)
+    HD_W = max(1, int(round(w * hd_scale)))
 
-    # Donut (top-right)
-    ref_h = max(int(h*0.06), int(REPS_FONT_SIZE*1.6))
+    pct = float(np.clip(progress_pct, 0, 1))
+    ref_h = max(int(HD_H * 0.06), int(REPS_FONT_SIZE * 1.6))
     r = int(ref_h * DONUT_RADIUS_SCALE)
     thick = max(3, int(r * DONUT_THICKNESS_FRAC))
-    m = 12; cx = w - m - r; cy = max(ref_h + r//8, r + thick//2 + 2)
-    frame = _donut(frame, (cx,cy), r, thick, float(np.clip(progress_pct,0,1)))
+    m = 12
+    cx = HD_W - m - r
+    cy = max(ref_h + r // 8, r + thick // 2 + 2)
 
-    pil = Image.fromarray(frame); d = ImageDraw.Draw(pil)
-    label = "DEPTH"; pct = f"{int(float(np.clip(progress_pct,0,1))*100)}%"
-    lw = d.textlength(label, font=DEPTH_LABEL_FONT); pw = d.textlength(pct, font=DEPTH_PCT_FONT)
-    gap = max(2, int(r*0.10)); base = cy - (DEPTH_LABEL_FONT.size + gap + DEPTH_PCT_FONT.size)//2
-    d.text((cx-int(lw//2), base), label, font=DEPTH_LABEL_FONT, fill=(255,255,255))
-    d.text((cx-int(pw//2), base+DEPTH_LABEL_FONT.size+gap), pct, font=DEPTH_PCT_FONT, fill=(255,255,255))
-    frame = np.array(pil)
+    overlay_bgr = np.zeros((HD_H, HD_W, 3), dtype=np.uint8)
+    overlay_a = np.zeros((HD_H, HD_W), dtype=np.uint8)
+    bg_alpha = int(round(255 * BAR_BG_ALPHA))
 
-    # Feedback (bottom)
+    txt = f"Reps: {reps}"
+    padx, pady = 10, 6
+    tmp = ImageDraw.Draw(Image.new("RGBA", (1, 1)))
+    tw = tmp.textlength(txt, font=REPS_FONT)
+    th = REPS_FONT.size
+    cv2.rectangle(overlay_bgr, (0, 0), (int(tw + 2 * padx), int(th + 2 * pady)), (0, 0, 0), -1)
+    cv2.rectangle(overlay_a, (0, 0), (int(tw + 2 * padx), int(th + 2 * pady)), bg_alpha, -1)
+
+    cv2.circle(overlay_bgr, (cx, cy), r, DEPTH_RING_BG, thick, cv2.LINE_AA)
+    cv2.circle(overlay_a, (cx, cy), r, 255, thick, cv2.LINE_AA)
+    cv2.ellipse(overlay_bgr, (cx, cy), (r, r), 0, -90, -90 + int(360 * pct), DEPTH_COLOR, thick, cv2.LINE_AA)
+    cv2.ellipse(overlay_a, (cx, cy), (r, r), 0, -90, -90 + int(360 * pct), 255, thick, cv2.LINE_AA)
+
+    pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+    pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+    pil = Image.fromarray(pil_rgba)
+    d = ImageDraw.Draw(pil)
+    d.text((padx, pady - 1), txt, font=REPS_FONT, fill=(255, 255, 255, 255))
+
+    label = "DEPTH"
+    pct_txt = f"{int(pct * 100)}%"
+    lw = d.textlength(label, font=DEPTH_LABEL_FONT)
+    pw = d.textlength(pct_txt, font=DEPTH_PCT_FONT)
+    gap = max(2, int(r * 0.10))
+    base = cy - (DEPTH_LABEL_FONT.size + gap + DEPTH_PCT_FONT.size) // 2
+    d.text((cx - int(lw // 2), base), label, font=DEPTH_LABEL_FONT, fill=(255, 255, 255, 255))
+    d.text((cx - int(pw // 2), base + DEPTH_LABEL_FONT.size + gap), pct_txt, font=DEPTH_PCT_FONT, fill=(255, 255, 255, 255))
+
     if feedback:
-        pil_fb = Image.fromarray(frame); dfb = ImageDraw.Draw(pil_fb)
-        safe = max(6, int(h*0.02)); pad_x, pad_y, lg = 12, 8, 4
-        maxw = int(w - 2*pad_x - 20)
-        lines = _wrap2(dfb, feedback, FEEDBACK_FONT, maxw)
+        safe = max(6, int(HD_H * 0.02))
+        pad_x, pad_y, lg = 12, 8, 4
+        maxw = int(HD_W - 2 * pad_x - 20)
+        lines = _wrap2(d, feedback, FEEDBACK_FONT, maxw)
         lh = FEEDBACK_FONT.size + 6
-        block = (2*pad_y) + len(lines)*lh + (len(lines)-1)*lg
-        y0 = max(0, h - safe - block); y1 = h - safe
-        over = frame.copy(); cv2.rectangle(over, (0,y0), (w,y1), (0,0,0), -1)
-        frame = cv2.addWeighted(over, BAR_BG_ALPHA, frame, 1-BAR_BG_ALPHA, 0)
-        pil_fb = Image.fromarray(frame); dfb = ImageDraw.Draw(pil_fb); ty = y0 + pad_y
+        block = (2 * pad_y) + len(lines) * lh + (len(lines) - 1) * lg
+        y0 = max(0, HD_H - safe - block)
+        y1 = HD_H - safe
+        cv2.rectangle(overlay_bgr, (0, y0), (HD_W, y1), (0, 0, 0), -1)
+        cv2.rectangle(overlay_a, (0, y0), (HD_W, y1), bg_alpha, -1)
+
+        pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+        pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+        pil = Image.fromarray(pil_rgba)
+        dfb = ImageDraw.Draw(pil)
+        ty = y0 + pad_y
         for ln in lines:
-            t_w = dfb.textlength(ln, font=FEEDBACK_FONT); tx = max(pad_x, (w - int(t_w)) // 2)
-            dfb.text((tx,ty), ln, font=FEEDBACK_FONT, fill=(255,255,255)); ty += lh + lg
-        frame = np.array(pil_fb)
-    return frame
+            t_w = dfb.textlength(ln, font=FEEDBACK_FONT)
+            tx = max(pad_x, (HD_W - int(t_w)) // 2)
+            dfb.text((tx, ty), ln, font=FEEDBACK_FONT, fill=(255, 255, 255, 255))
+            ty += lh + lg
+
+    overlay_rgba = np.array(pil)
+    overlay_small = cv2.resize(overlay_rgba, (w, h), interpolation=cv2.INTER_AREA)
+    alpha = overlay_small[:, :, 3:4].astype(np.float32) / 255.0
+    rgb = cv2.cvtColor(overlay_small[:, :, :3], cv2.COLOR_RGB2BGR).astype(np.float32)
+    out = frame.astype(np.float32) * (1.0 - alpha) + rgb * alpha
+    return out.astype(np.uint8)
 
 # ===================== MAIN =====================
 def run_deadlift_analysis(video_path,

--- a/dips_analysis.py
+++ b/dips_analysis.py
@@ -92,43 +92,83 @@ def draw_body_only(frame, lms, color=(255,255,255)):
     return frame
 
 def draw_overlay(frame, reps=0, feedback=None, depth_pct=0.0):
-    h,w,_=frame.shape
-    ref_h=max(int(h*0.06),int(REPS_FONT_SIZE*1.6))
-    r=int(ref_h*DONUT_RADIUS_SCALE); th=max(3,int(r*DONUT_THICKNESS_FRAC))
-    m=12; cx=w-m-r; cy=max(ref_h+r//8, r+th//2+2)
-    pct=float(np.clip(depth_pct,0,1))
-    cv2.circle(frame,(cx,cy),r,DEPTH_RING_BG,th,cv2.LINE_AA)
-    cv2.ellipse(frame,(cx,cy),(r,r),0,-90,-90+int(360*pct),DEPTH_COLOR,th,cv2.LINE_AA)
-    pil=Image.fromarray(cv2.cvtColor(frame,cv2.COLOR_BGR2RGB)); draw=ImageDraw.Draw(pil)
+    h, w, _ = frame.shape
+    HD_H = 1080
+    hd_scale = HD_H / float(h)
+    HD_W = max(1, int(round(w * hd_scale)))
 
-    txt=f"Reps: {int(reps)}"; pad_x,pad_y=10,6
-    tw=draw.textlength(txt,font=REPS_FONT); thh=REPS_FONT.size
-    base=np.array(pil); over=base.copy()
-    cv2.rectangle(over,(0,0),(int(tw+2*pad_x),int(thh+2*pad_y)),(0,0,0),-1)
-    base=cv2.addWeighted(over,BAR_BG_ALPHA,base,1-BAR_BG_ALPHA,0)
-    pil=Image.fromarray(base); draw=ImageDraw.Draw(pil)
-    draw.text((pad_x,pad_y-1),txt,font=REPS_FONT,fill=(255,255,255))
+    pct = float(np.clip(depth_pct, 0, 1))
+    ref_h = max(int(HD_H * 0.06), int(REPS_FONT_SIZE * 1.6))
+    r = int(ref_h * DONUT_RADIUS_SCALE)
+    th = max(3, int(r * DONUT_THICKNESS_FRAC))
+    m = 12
+    cx = HD_W - m - r
+    cy = max(ref_h + r // 8, r + th // 2 + 2)
 
-    gap=max(2,int(r*0.10)); by=cy-(DEPTH_LABEL_FONT.size+gap+DEPTH_PCT_FONT.size)//2
-    label="DEPTH"; pct_txt=f"{int(pct*100)}%"
-    lw=draw.textlength(label,font=DEPTH_LABEL_FONT); pw=draw.textlength(pct_txt,font=DEPTH_PCT_FONT)
-    draw.text((cx-int(lw//2),by),label,font=DEPTH_LABEL_FONT,fill=(255,255,255))
-    draw.text((cx-int(pw//2),by+DEPTH_LABEL_FONT.size+gap),pct_txt,font=DEPTH_PCT_FONT,fill=(255,255,255))
+    REPS_FONT = _load_font(FONT_PATH, REPS_FONT_SIZE)
+    FEEDBACK_FONT = _load_font(FONT_PATH, FEEDBACK_FONT_SIZE)
+    DEPTH_LABEL_FONT = _load_font(FONT_PATH, DEPTH_LABEL_FONT_SIZE)
+    DEPTH_PCT_FONT = _load_font(FONT_PATH, DEPTH_PCT_FONT_SIZE)
+
+    overlay_bgr = np.zeros((HD_H, HD_W, 3), dtype=np.uint8)
+    overlay_a = np.zeros((HD_H, HD_W), dtype=np.uint8)
+    bg_alpha = int(round(255 * BAR_BG_ALPHA))
+
+    txt = f"Reps: {int(reps)}"
+    pad_x, pad_y = 10, 6
+    tmp = ImageDraw.Draw(Image.new("RGBA", (1, 1)))
+    tw = tmp.textlength(txt, font=REPS_FONT)
+    thh = REPS_FONT.size
+    cv2.rectangle(overlay_bgr, (0, 0), (int(tw + 2 * pad_x), int(thh + 2 * pad_y)), (0, 0, 0), -1)
+    cv2.rectangle(overlay_a, (0, 0), (int(tw + 2 * pad_x), int(thh + 2 * pad_y)), bg_alpha, -1)
+
+    cv2.circle(overlay_bgr, (cx, cy), r, DEPTH_RING_BG, th, cv2.LINE_AA)
+    cv2.circle(overlay_a, (cx, cy), r, 255, th, cv2.LINE_AA)
+    cv2.ellipse(overlay_bgr, (cx, cy), (r, r), 0, -90, -90 + int(360 * pct), DEPTH_COLOR, th, cv2.LINE_AA)
+    cv2.ellipse(overlay_a, (cx, cy), (r, r), 0, -90, -90 + int(360 * pct), 255, th, cv2.LINE_AA)
+
+    pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+    pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+    pil = Image.fromarray(pil_rgba)
+    draw = ImageDraw.Draw(pil)
+    draw.text((pad_x, pad_y - 1), txt, font=REPS_FONT, fill=(255, 255, 255, 255))
+
+    gap = max(2, int(r * 0.10))
+    by = cy - (DEPTH_LABEL_FONT.size + gap + DEPTH_PCT_FONT.size) // 2
+    label = "DEPTH"
+    pct_txt = f"{int(pct * 100)}%"
+    lw = draw.textlength(label, font=DEPTH_LABEL_FONT)
+    pw = draw.textlength(pct_txt, font=DEPTH_PCT_FONT)
+    draw.text((cx - int(lw // 2), by), label, font=DEPTH_LABEL_FONT, fill=(255, 255, 255, 255))
+    draw.text((cx - int(pw // 2), by + DEPTH_LABEL_FONT.size + gap), pct_txt, font=DEPTH_PCT_FONT, fill=(255, 255, 255, 255))
 
     if feedback:
-        max_w=int(w-2*12-20); lines=_wrap_two_lines(draw,feedback,FEEDBACK_FONT,max_w)
-        line_h=FEEDBACK_FONT.size+6
-        block_h=2*8+len(lines)*line_h+(len(lines)-1)*4
-        y0=max(0,h-max(6,int(h*0.02))-block_h); y1=h-max(6,int(h*0.02))
-        base2=np.array(pil); over2=base2.copy()
-        cv2.rectangle(over2,(0,y0),(w,y1),(0,0,0),-1)
-        base2=cv2.addWeighted(over2,BAR_BG_ALPHA,base2,1-BAR_BG_ALPHA,0)
-        pil=Image.fromarray(base2); draw=ImageDraw.Draw(pil)
-        ty=y0+8
+        max_w = int(HD_W - 2 * 12 - 20)
+        lines = _wrap_two_lines(draw, feedback, FEEDBACK_FONT, max_w)
+        line_h = FEEDBACK_FONT.size + 6
+        block_h = 2 * 8 + len(lines) * line_h + (len(lines) - 1) * 4
+        y0 = max(0, HD_H - max(6, int(HD_H * 0.02)) - block_h)
+        y1 = HD_H - max(6, int(HD_H * 0.02))
+        cv2.rectangle(overlay_bgr, (0, y0), (HD_W, y1), (0, 0, 0), -1)
+        cv2.rectangle(overlay_a, (0, y0), (HD_W, y1), bg_alpha, -1)
+
+        pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+        pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+        pil = Image.fromarray(pil_rgba)
+        draw = ImageDraw.Draw(pil)
+        ty = y0 + 8
         for ln in lines:
-            tw2=draw.textlength(ln,font=FEEDBACK_FONT); tx=max(12,(w-int(tw2))//2)
-            draw.text((tx,ty),ln,font=FEEDBACK_FONT,fill=(255,255,255)); ty+=line_h+4
-    return cv2.cvtColor(np.array(pil),cv2.COLOR_RGB2BGR)
+            tw2 = draw.textlength(ln, font=FEEDBACK_FONT)
+            tx = max(12, (HD_W - int(tw2)) // 2)
+            draw.text((tx, ty), ln, font=FEEDBACK_FONT, fill=(255, 255, 255, 255))
+            ty += line_h + 4
+
+    overlay_rgba = np.array(pil)
+    overlay_small = cv2.resize(overlay_rgba, (w, h), interpolation=cv2.INTER_AREA)
+    alpha = overlay_small[:, :, 3:4].astype(np.float32) / 255.0
+    rgb = cv2.cvtColor(overlay_small[:, :, :3], cv2.COLOR_RGB2BGR).astype(np.float32)
+    out = frame.astype(np.float32) * (1.0 - alpha) + rgb * alpha
+    return out.astype(np.uint8)
 
 # ============ Dips Parameters ============
 # ספירת חזרות

--- a/good_morning_analysis.py
+++ b/good_morning_analysis.py
@@ -180,41 +180,50 @@ def _wrap_two_lines(draw, text, font, max_width):
 def draw_overlay(frame, reps=0, feedback=None, depth_pct=0.0):
     """Reps top-left; donut top-right; feedback bottom — matches pullup overlay sizing."""
     h, w, _ = frame.shape
-    ref_h = max(int(h * 0.06), int(_scaled_font_size(_REF_REPS_FONT_SIZE, h) * 1.6))
-    r = int(ref_h * DONUT_RADIUS_SCALE)
-    th = max(3, int(r * DONUT_THICKNESS_FRAC))
-    m = 12
-    cx = w - m - r
-    cy = max(ref_h + r // 8, r + th // 2 + 2)
-    pct = float(np.clip(depth_pct, 0, 1))
-    cv2.circle(frame, (cx, cy), r, DEPTH_RING_BG, th, cv2.LINE_AA)
-    cv2.ellipse(frame, (cx, cy), (r, r), 0, -90, -90 + int(360 * pct), DEPTH_COLOR, th, cv2.LINE_AA)
+    HD_H = 1080
+    hd_scale = HD_H / float(h)
+    HD_W = max(1, int(round(w * hd_scale)))
 
-    # Scale all font sizes proportionally to frame height
-    reps_font_size = _scaled_font_size(_REF_REPS_FONT_SIZE, h)
-    feedback_font_size = _scaled_font_size(_REF_FEEDBACK_FONT_SIZE, h)
-    depth_label_font_size = _scaled_font_size(_REF_DEPTH_LABEL_FONT_SIZE, h)
-    depth_pct_font_size = _scaled_font_size(_REF_DEPTH_PCT_FONT_SIZE, h)
+    reps_font_size = _scaled_font_size(_REF_REPS_FONT_SIZE, HD_H)
+    feedback_font_size = _scaled_font_size(_REF_FEEDBACK_FONT_SIZE, HD_H)
+    depth_label_font_size = _scaled_font_size(_REF_DEPTH_LABEL_FONT_SIZE, HD_H)
+    depth_pct_font_size = _scaled_font_size(_REF_DEPTH_PCT_FONT_SIZE, HD_H)
 
     _REPS_FONT = _load_font(FONT_PATH, reps_font_size)
     _FEEDBACK_FONT = _load_font(FONT_PATH, feedback_font_size)
     _DEPTH_LABEL_FONT = _load_font(FONT_PATH, depth_label_font_size)
     _DEPTH_PCT_FONT = _load_font(FONT_PATH, depth_pct_font_size)
 
-    pil = Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
-    draw = ImageDraw.Draw(pil)
+    pct = float(np.clip(depth_pct, 0, 1))
+    ref_h = max(int(HD_H * 0.06), int(reps_font_size * 1.6))
+    r = int(ref_h * DONUT_RADIUS_SCALE)
+    th = max(3, int(r * DONUT_THICKNESS_FRAC))
+    m = 12
+    cx = HD_W - m - r
+    cy = max(ref_h + r // 8, r + th // 2 + 2)
+
+    overlay_bgr = np.zeros((HD_H, HD_W, 3), dtype=np.uint8)
+    overlay_a = np.zeros((HD_H, HD_W), dtype=np.uint8)
+    bg_alpha = int(round(255 * BAR_BG_ALPHA))
 
     txt = f"Reps: {int(reps)}"
     pad_x, pad_y = 10, 6
-    tw = draw.textlength(txt, font=_REPS_FONT)
+    tmp = ImageDraw.Draw(Image.new("RGBA", (1, 1)))
+    tw = tmp.textlength(txt, font=_REPS_FONT)
     thh = _REPS_FONT.size
-    base = np.array(pil)
-    over = base.copy()
-    cv2.rectangle(over, (0, 0), (int(tw + 2 * pad_x), int(thh + 2 * pad_y)), (0, 0, 0), -1)
-    base = cv2.addWeighted(over, BAR_BG_ALPHA, base, 1 - BAR_BG_ALPHA, 0)
-    pil = Image.fromarray(base)
+    cv2.rectangle(overlay_bgr, (0, 0), (int(tw + 2 * pad_x), int(thh + 2 * pad_y)), (0, 0, 0), -1)
+    cv2.rectangle(overlay_a, (0, 0), (int(tw + 2 * pad_x), int(thh + 2 * pad_y)), bg_alpha, -1)
+
+    cv2.circle(overlay_bgr, (cx, cy), r, DEPTH_RING_BG, th, cv2.LINE_AA)
+    cv2.circle(overlay_a, (cx, cy), r, 255, th, cv2.LINE_AA)
+    cv2.ellipse(overlay_bgr, (cx, cy), (r, r), 0, -90, -90 + int(360 * pct), DEPTH_COLOR, th, cv2.LINE_AA)
+    cv2.ellipse(overlay_a, (cx, cy), (r, r), 0, -90, -90 + int(360 * pct), 255, th, cv2.LINE_AA)
+
+    pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+    pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+    pil = Image.fromarray(pil_rgba)
     draw = ImageDraw.Draw(pil)
-    draw.text((pad_x, pad_y - 1), txt, font=_REPS_FONT, fill=(255, 255, 255))
+    draw.text((pad_x, pad_y - 1), txt, font=_REPS_FONT, fill=(255, 255, 255, 255))
 
     gap = max(2, int(r * 0.10))
     by = cy - (_DEPTH_LABEL_FONT.size + gap + _DEPTH_PCT_FONT.size) // 2
@@ -222,30 +231,36 @@ def draw_overlay(frame, reps=0, feedback=None, depth_pct=0.0):
     pct_txt = f"{int(pct * 100)}%"
     lw = draw.textlength(label, font=_DEPTH_LABEL_FONT)
     pw = draw.textlength(pct_txt, font=_DEPTH_PCT_FONT)
-    draw.text((cx - int(lw // 2), by), label, font=_DEPTH_LABEL_FONT, fill=(255, 255, 255))
-    draw.text((cx - int(pw // 2), by + _DEPTH_LABEL_FONT.size + gap), pct_txt, font=_DEPTH_PCT_FONT, fill=(255, 255, 255))
+    draw.text((cx - int(lw // 2), by), label, font=_DEPTH_LABEL_FONT, fill=(255, 255, 255, 255))
+    draw.text((cx - int(pw // 2), by + _DEPTH_LABEL_FONT.size + gap), pct_txt, font=_DEPTH_PCT_FONT, fill=(255, 255, 255, 255))
 
     if feedback:
-        max_w = int(w - 2 * 12 - 20)
+        max_w = int(HD_W - 2 * 12 - 20)
         lines = _wrap_two_lines(draw, feedback, _FEEDBACK_FONT, max_w)
         line_h = _FEEDBACK_FONT.size + 6
         block_h = 2 * 8 + len(lines) * line_h + (len(lines) - 1) * 4
-        y0 = max(0, h - max(6, int(h * 0.02)) - block_h)
-        y1 = h - max(6, int(h * 0.02))
-        base2 = np.array(pil)
-        over2 = base2.copy()
-        cv2.rectangle(over2, (0, y0), (w, y1), (0, 0, 0), -1)
-        base2 = cv2.addWeighted(over2, BAR_BG_ALPHA, base2, 1 - BAR_BG_ALPHA, 0)
-        pil = Image.fromarray(base2)
+        y0 = max(0, HD_H - max(6, int(HD_H * 0.02)) - block_h)
+        y1 = HD_H - max(6, int(HD_H * 0.02))
+        cv2.rectangle(overlay_bgr, (0, y0), (HD_W, y1), (0, 0, 0), -1)
+        cv2.rectangle(overlay_a, (0, y0), (HD_W, y1), bg_alpha, -1)
+
+        pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+        pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+        pil = Image.fromarray(pil_rgba)
         draw = ImageDraw.Draw(pil)
         ty = y0 + 8
         for ln in lines:
             tw2 = draw.textlength(ln, font=_FEEDBACK_FONT)
-            tx = max(12, (w - int(tw2)) // 2)
-            draw.text((tx, ty), ln, font=_FEEDBACK_FONT, fill=(255, 255, 255))
+            tx = max(12, (HD_W - int(tw2)) // 2)
+            draw.text((tx, ty), ln, font=_FEEDBACK_FONT, fill=(255, 255, 255, 255))
             ty += line_h + 4
 
-    return cv2.cvtColor(np.array(pil), cv2.COLOR_RGB2BGR)
+    overlay_rgba = np.array(pil)
+    overlay_small = cv2.resize(overlay_rgba, (w, h), interpolation=cv2.INTER_AREA)
+    alpha = overlay_small[:, :, 3:4].astype(np.float32) / 255.0
+    rgb = cv2.cvtColor(overlay_small[:, :, :3], cv2.COLOR_RGB2BGR).astype(np.float32)
+    out = frame.astype(np.float32) * (1.0 - alpha) + rgb * alpha
+    return out.astype(np.uint8)
 
 # ===================== GEOMETRY =====================
 def angle_deg(a, b, c):

--- a/overhead_press_analysis.py
+++ b/overhead_press_analysis.py
@@ -358,68 +358,78 @@ def draw_overlay(frame, reps=0, feedback=None, height_pct=0.0, phase_name=""):
         return frame
 
     h, w, _ = frame.shape
+    HD_H = 1080
+    hd_scale = HD_H / float(h)
+    HD_W = max(1, int(round(w * hd_scale)))
 
-    # Donut ring for height progress
-    ref_h = max(int(h * 0.06), int(REPS_FONT_SIZE * 1.6))
+    pct = float(np.clip(height_pct, 0, 1))
+    ref_h = max(int(HD_H * 0.06), int(REPS_FONT_SIZE * 1.6))
     r = int(ref_h * DONUT_RADIUS_SCALE)
     th = max(3, int(r * DONUT_THICKNESS_FRAC))
     m = 12
-    cx = w - m - r
+    cx = HD_W - m - r
     cy = max(ref_h + r // 8, r + th // 2 + 2)
-    pct = float(np.clip(height_pct, 0, 1))
-    cv2.circle(frame, (cx, cy), r, DEPTH_RING_BG, th, cv2.LINE_AA)
-    cv2.ellipse(frame, (cx, cy), (r, r), 0, -90, -90 + int(360 * pct), DEPTH_COLOR, th, cv2.LINE_AA)
 
-    pil = Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
-    draw = ImageDraw.Draw(pil)
+    overlay_bgr = np.zeros((HD_H, HD_W, 3), dtype=np.uint8)
+    overlay_a = np.zeros((HD_H, HD_W), dtype=np.uint8)
+    bg_alpha = int(round(255 * BAR_BG_ALPHA))
 
-    # Rep counter (top-left)
     txt = f"Reps: {int(reps)}"
     pad_x, pad_y = 10, 6
-    tw = draw.textlength(txt, font=REPS_FONT)
+    tmp = ImageDraw.Draw(Image.new("RGBA", (1, 1)))
+    tw = tmp.textlength(txt, font=REPS_FONT)
     thh = REPS_FONT.size
-    base = np.array(pil)
-    over = base.copy()
-    cv2.rectangle(over, (0, 0), (int(tw + 2 * pad_x), int(thh + 2 * pad_y)), (0, 0, 0), -1)
-    base = cv2.addWeighted(over, BAR_BG_ALPHA, base, 1 - BAR_BG_ALPHA, 0)
-    pil = Image.fromarray(base)
-    draw = ImageDraw.Draw(pil)
-    draw.text((pad_x, pad_y - 1), txt, font=REPS_FONT, fill=(255, 255, 255))
+    cv2.rectangle(overlay_bgr, (0, 0), (int(tw + 2 * pad_x), int(thh + 2 * pad_y)), (0, 0, 0), -1)
+    cv2.rectangle(overlay_a, (0, 0), (int(tw + 2 * pad_x), int(thh + 2 * pad_y)), bg_alpha, -1)
 
-    # Height label inside donut
+    cv2.circle(overlay_bgr, (cx, cy), r, DEPTH_RING_BG, th, cv2.LINE_AA)
+    cv2.circle(overlay_a, (cx, cy), r, 255, th, cv2.LINE_AA)
+    cv2.ellipse(overlay_bgr, (cx, cy), (r, r), 0, -90, -90 + int(360 * pct), DEPTH_COLOR, th, cv2.LINE_AA)
+    cv2.ellipse(overlay_a, (cx, cy), (r, r), 0, -90, -90 + int(360 * pct), 255, th, cv2.LINE_AA)
+
+    pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+    pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+    pil = Image.fromarray(pil_rgba)
+    draw = ImageDraw.Draw(pil)
+    draw.text((pad_x, pad_y - 1), txt, font=REPS_FONT, fill=(255, 255, 255, 255))
+
     gap = max(2, int(r * 0.10))
     by = cy - (DEPTH_LABEL_FONT.size + gap + DEPTH_PCT_FONT.size) // 2
     label = "HEIGHT"
     pct_txt = f"{int(pct * 100)}%"
     lw = draw.textlength(label, font=DEPTH_LABEL_FONT)
     pw = draw.textlength(pct_txt, font=DEPTH_PCT_FONT)
-    draw.text((cx - int(lw // 2), by), label, font=DEPTH_LABEL_FONT, fill=(255, 255, 255))
+    draw.text((cx - int(lw // 2), by), label, font=DEPTH_LABEL_FONT, fill=(255, 255, 255, 255))
     draw.text((cx - int(pw // 2), by + DEPTH_LABEL_FONT.size + gap), pct_txt,
-              font=DEPTH_PCT_FONT, fill=(255, 255, 255))
+              font=DEPTH_PCT_FONT, fill=(255, 255, 255, 255))
 
-    # Feedback bar (bottom)
     if feedback:
-        max_w = int(w - 2 * 12 - 20)
+        max_w = int(HD_W - 2 * 12 - 20)
         lines = _wrap_two_lines(draw, feedback, FEEDBACK_FONT, max_w)
         line_h = FEEDBACK_FONT.size + 6
         block_h = 2 * 8 + len(lines) * line_h + (len(lines) - 1) * 4
-        y0 = max(0, h - max(6, int(h * 0.02)) - block_h)
-        y1 = h - max(6, int(h * 0.02))
-        base2 = np.array(pil)
-        over2 = base2.copy()
-        cv2.rectangle(over2, (0, y0), (w, y1), (0, 0, 0), -1)
-        base2 = cv2.addWeighted(over2, BAR_BG_ALPHA, base2, 1 - BAR_BG_ALPHA, 0)
-        pil = Image.fromarray(base2)
+        y0 = max(0, HD_H - max(6, int(HD_H * 0.02)) - block_h)
+        y1 = HD_H - max(6, int(HD_H * 0.02))
+        cv2.rectangle(overlay_bgr, (0, y0), (HD_W, y1), (0, 0, 0), -1)
+        cv2.rectangle(overlay_a, (0, y0), (HD_W, y1), bg_alpha, -1)
+
+        pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+        pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+        pil = Image.fromarray(pil_rgba)
         draw = ImageDraw.Draw(pil)
         ty = y0 + 8
         for ln in lines:
             tw2 = draw.textlength(ln, font=FEEDBACK_FONT)
-            tx = max(12, (w - int(tw2)) // 2)
-            draw.text((tx, ty), ln, font=FEEDBACK_FONT, fill=(255, 255, 255))
+            tx = max(12, (HD_W - int(tw2)) // 2)
+            draw.text((tx, ty), ln, font=FEEDBACK_FONT, fill=(255, 255, 255, 255))
             ty += line_h + 4
 
-    return cv2.cvtColor(np.array(pil), cv2.COLOR_RGB2BGR)
-
+    overlay_rgba = np.array(pil)
+    overlay_small = cv2.resize(overlay_rgba, (w, h), interpolation=cv2.INTER_AREA)
+    alpha = overlay_small[:, :, 3:4].astype(np.float32) / 255.0
+    rgb = cv2.cvtColor(overlay_small[:, :, :3], cv2.COLOR_RGB2BGR).astype(np.float32)
+    out = frame.astype(np.float32) * (1.0 - alpha) + rgb * alpha
+    return out.astype(np.uint8)
 
 # ============ State Machine Rep Counter ============
 

--- a/pullup_analysis.py
+++ b/pullup_analysis.py
@@ -107,49 +107,83 @@ def draw_body_only(frame, lms, color=(255,255,255)):
     return frame
 
 def draw_overlay(frame, reps=0, feedback=None, height_pct=0.0):
-    h,w,_=frame.shape
-    ref_h=max(int(h*0.06),int(REPS_FONT_SIZE*1.6))
-    r=int(ref_h*DONUT_RADIUS_SCALE); th=max(3,int(r*DONUT_THICKNESS_FRAC))
-    m=12; cx=w-m-r; cy=max(ref_h+r//8, r+th//2+2)
-    pct=float(np.clip(height_pct,0,1))
-    cv2.circle(frame,(cx,cy),r,DEPTH_RING_BG,th,cv2.LINE_AA)
-    cv2.ellipse(frame,(cx,cy),(r,r),0,-90,-90+int(360*pct),DEPTH_COLOR,th,cv2.LINE_AA)
-    
-    REPS_FONT=_load_font(FONT_PATH,REPS_FONT_SIZE)
-    FEEDBACK_FONT=_load_font(FONT_PATH,FEEDBACK_FONT_SIZE)
-    DEPTH_LABEL_FONT=_load_font(FONT_PATH,DEPTH_LABEL_FONT_SIZE)
-    DEPTH_PCT_FONT=_load_font(FONT_PATH,DEPTH_PCT_FONT_SIZE)
-    
-    pil=Image.fromarray(cv2.cvtColor(frame,cv2.COLOR_BGR2RGB)); draw=ImageDraw.Draw(pil)
+    h, w, _ = frame.shape
+    HD_H = 1080
+    hd_scale = HD_H / float(h)
+    HD_W = max(1, int(round(w * hd_scale)))
 
-    txt=f"Reps: {int(reps)}"; pad_x,pad_y=10,6
-    tw=draw.textlength(txt,font=REPS_FONT); thh=REPS_FONT.size
-    base=np.array(pil); over=base.copy()
-    cv2.rectangle(over,(0,0),(int(tw+2*pad_x),int(thh+2*pad_y)),(0,0,0),-1)
-    base=cv2.addWeighted(over,BAR_BG_ALPHA,base,1-BAR_BG_ALPHA,0)
-    pil=Image.fromarray(base); draw=ImageDraw.Draw(pil)
-    draw.text((pad_x,pad_y-1),txt,font=REPS_FONT,fill=(255,255,255))
+    pct = float(np.clip(height_pct, 0, 1))
+    ref_h = max(int(HD_H * 0.06), int(REPS_FONT_SIZE * 1.6))
+    r = int(ref_h * DONUT_RADIUS_SCALE)
+    th = max(3, int(r * DONUT_THICKNESS_FRAC))
+    m = 12
+    cx = HD_W - m - r
+    cy = max(ref_h + r // 8, r + th // 2 + 2)
 
-    gap=max(2,int(r*0.10)); by=cy-(DEPTH_LABEL_FONT.size+gap+DEPTH_PCT_FONT.size)//2
-    label="HEIGHT"; pct_txt=f"{int(pct*100)}%"
-    lw=draw.textlength(label,font=DEPTH_LABEL_FONT); pw=draw.textlength(pct_txt,font=DEPTH_PCT_FONT)
-    draw.text((cx-int(lw//2),by),label,font=DEPTH_LABEL_FONT,fill=(255,255,255))
-    draw.text((cx-int(pw//2),by+DEPTH_LABEL_FONT.size+gap),pct_txt,font=DEPTH_PCT_FONT,fill=(255,255,255))
+    REPS_FONT = _load_font(FONT_PATH, REPS_FONT_SIZE)
+    FEEDBACK_FONT = _load_font(FONT_PATH, FEEDBACK_FONT_SIZE)
+    DEPTH_LABEL_FONT = _load_font(FONT_PATH, DEPTH_LABEL_FONT_SIZE)
+    DEPTH_PCT_FONT = _load_font(FONT_PATH, DEPTH_PCT_FONT_SIZE)
+
+    overlay_bgr = np.zeros((HD_H, HD_W, 3), dtype=np.uint8)
+    overlay_a = np.zeros((HD_H, HD_W), dtype=np.uint8)
+    bg_alpha = int(round(255 * BAR_BG_ALPHA))
+
+    txt = f"Reps: {int(reps)}"
+    pad_x, pad_y = 10, 6
+    tmp = ImageDraw.Draw(Image.new("RGBA", (1, 1)))
+    tw = tmp.textlength(txt, font=REPS_FONT)
+    thh = REPS_FONT.size
+    cv2.rectangle(overlay_bgr, (0, 0), (int(tw + 2 * pad_x), int(thh + 2 * pad_y)), (0, 0, 0), -1)
+    cv2.rectangle(overlay_a, (0, 0), (int(tw + 2 * pad_x), int(thh + 2 * pad_y)), bg_alpha, -1)
+
+    cv2.circle(overlay_bgr, (cx, cy), r, DEPTH_RING_BG, th, cv2.LINE_AA)
+    cv2.circle(overlay_a, (cx, cy), r, 255, th, cv2.LINE_AA)
+    cv2.ellipse(overlay_bgr, (cx, cy), (r, r), 0, -90, -90 + int(360 * pct), DEPTH_COLOR, th, cv2.LINE_AA)
+    cv2.ellipse(overlay_a, (cx, cy), (r, r), 0, -90, -90 + int(360 * pct), 255, th, cv2.LINE_AA)
+
+    pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+    pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+    pil = Image.fromarray(pil_rgba)
+    draw = ImageDraw.Draw(pil)
+    draw.text((pad_x, pad_y - 1), txt, font=REPS_FONT, fill=(255, 255, 255, 255))
+
+    gap = max(2, int(r * 0.10))
+    by = cy - (DEPTH_LABEL_FONT.size + gap + DEPTH_PCT_FONT.size) // 2
+    label = "HEIGHT"
+    pct_txt = f"{int(pct * 100)}%"
+    lw = draw.textlength(label, font=DEPTH_LABEL_FONT)
+    pw = draw.textlength(pct_txt, font=DEPTH_PCT_FONT)
+    draw.text((cx - int(lw // 2), by), label, font=DEPTH_LABEL_FONT, fill=(255, 255, 255, 255))
+    draw.text((cx - int(pw // 2), by + DEPTH_LABEL_FONT.size + gap), pct_txt, font=DEPTH_PCT_FONT, fill=(255, 255, 255, 255))
 
     if feedback:
-        max_w=int(w-2*12-20); lines=_wrap_two_lines(draw,feedback,FEEDBACK_FONT,max_w)
-        line_h=FEEDBACK_FONT.size+6
-        block_h=2*8+len(lines)*line_h+(len(lines)-1)*4
-        y0=max(0,h-max(6,int(h*0.02))-block_h); y1=h-max(6,int(h*0.02))
-        base2=np.array(pil); over2=base2.copy()
-        cv2.rectangle(over2,(0,y0),(w,y1),(0,0,0),-1)
-        base2=cv2.addWeighted(over2,BAR_BG_ALPHA,base2,1-BAR_BG_ALPHA,0)
-        pil=Image.fromarray(base2); draw=ImageDraw.Draw(pil)
-        ty=y0+8
+        max_w = int(HD_W - 2 * 12 - 20)
+        lines = _wrap_two_lines(draw, feedback, FEEDBACK_FONT, max_w)
+        line_h = FEEDBACK_FONT.size + 6
+        block_h = 2 * 8 + len(lines) * line_h + (len(lines) - 1) * 4
+        y0 = max(0, HD_H - max(6, int(HD_H * 0.02)) - block_h)
+        y1 = HD_H - max(6, int(HD_H * 0.02))
+        cv2.rectangle(overlay_bgr, (0, y0), (HD_W, y1), (0, 0, 0), -1)
+        cv2.rectangle(overlay_a, (0, y0), (HD_W, y1), bg_alpha, -1)
+
+        pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+        pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+        pil = Image.fromarray(pil_rgba)
+        draw = ImageDraw.Draw(pil)
+        ty = y0 + 8
         for ln in lines:
-            tw2=draw.textlength(ln,font=FEEDBACK_FONT); tx=max(12,(w-int(tw2))//2)
-            draw.text((tx,ty),ln,font=FEEDBACK_FONT,fill=(255,255,255)); ty+=line_h+4
-    return cv2.cvtColor(np.array(pil),cv2.COLOR_RGB2BGR)
+            tw2 = draw.textlength(ln, font=FEEDBACK_FONT)
+            tx = max(12, (HD_W - int(tw2)) // 2)
+            draw.text((tx, ty), ln, font=FEEDBACK_FONT, fill=(255, 255, 255, 255))
+            ty += line_h + 4
+
+    overlay_rgba = np.array(pil)
+    overlay_small = cv2.resize(overlay_rgba, (w, h), interpolation=cv2.INTER_AREA)
+    alpha = overlay_small[:, :, 3:4].astype(np.float32) / 255.0
+    rgb = cv2.cvtColor(overlay_small[:, :, :3], cv2.COLOR_RGB2BGR).astype(np.float32)
+    out = frame.astype(np.float32) * (1.0 - alpha) + rgb * alpha
+    return out.astype(np.uint8)
 
 # ============ Params ============
 ELBOW_TOP_ANGLE=100.0

--- a/pushup_analysis.py
+++ b/pushup_analysis.py
@@ -89,43 +89,83 @@ def draw_body_only(frame, lms, color=(255,255,255)):
     return frame
 
 def draw_overlay(frame, reps=0, feedback=None, depth_pct=0.0):
-    h,w,_=frame.shape
-    ref_h=max(int(h*0.06),int(REPS_FONT_SIZE*1.6))
-    r=int(ref_h*DONUT_RADIUS_SCALE); th=max(3,int(r*DONUT_THICKNESS_FRAC))
-    m=12; cx=w-m-r; cy=max(ref_h+r//8, r+th//2+2)
-    pct=float(np.clip(depth_pct,0,1))
-    cv2.circle(frame,(cx,cy),r,DEPTH_RING_BG,th,cv2.LINE_AA)
-    cv2.ellipse(frame,(cx,cy),(r,r),0,-90,-90+int(360*pct),DEPTH_COLOR,th,cv2.LINE_AA)
-    pil=Image.fromarray(cv2.cvtColor(frame,cv2.COLOR_BGR2RGB)); draw=ImageDraw.Draw(pil)
+    h, w, _ = frame.shape
+    HD_H = 1080
+    hd_scale = HD_H / float(h)
+    HD_W = max(1, int(round(w * hd_scale)))
 
-    txt=f"Reps: {int(reps)}"; pad_x,pad_y=10,6
-    tw=draw.textlength(txt,font=REPS_FONT); thh=REPS_FONT.size
-    base=np.array(pil); over=base.copy()
-    cv2.rectangle(over,(0,0),(int(tw+2*pad_x),int(thh+2*pad_y)),(0,0,0),-1)
-    base=cv2.addWeighted(over,BAR_BG_ALPHA,base,1-BAR_BG_ALPHA,0)
-    pil=Image.fromarray(base); draw=ImageDraw.Draw(pil)
-    draw.text((pad_x,pad_y-1),txt,font=REPS_FONT,fill=(255,255,255))
+    pct = float(np.clip(depth_pct, 0, 1))
+    ref_h = max(int(HD_H * 0.06), int(REPS_FONT_SIZE * 1.6))
+    r = int(ref_h * DONUT_RADIUS_SCALE)
+    th = max(3, int(r * DONUT_THICKNESS_FRAC))
+    m = 12
+    cx = HD_W - m - r
+    cy = max(ref_h + r // 8, r + th // 2 + 2)
 
-    gap=max(2,int(r*0.10)); by=cy-(DEPTH_LABEL_FONT.size+gap+DEPTH_PCT_FONT.size)//2
-    label="DEPTH"; pct_txt=f"{int(pct*100)}%"
-    lw=draw.textlength(label,font=DEPTH_LABEL_FONT); pw=draw.textlength(pct_txt,font=DEPTH_PCT_FONT)
-    draw.text((cx-int(lw//2),by),label,font=DEPTH_LABEL_FONT,fill=(255,255,255))
-    draw.text((cx-int(pw//2),by+DEPTH_LABEL_FONT.size+gap),pct_txt,font=DEPTH_PCT_FONT,fill=(255,255,255))
+    REPS_FONT = _load_font(FONT_PATH, REPS_FONT_SIZE)
+    FEEDBACK_FONT = _load_font(FONT_PATH, FEEDBACK_FONT_SIZE)
+    DEPTH_LABEL_FONT = _load_font(FONT_PATH, DEPTH_LABEL_FONT_SIZE)
+    DEPTH_PCT_FONT = _load_font(FONT_PATH, DEPTH_PCT_FONT_SIZE)
+
+    overlay_bgr = np.zeros((HD_H, HD_W, 3), dtype=np.uint8)
+    overlay_a = np.zeros((HD_H, HD_W), dtype=np.uint8)
+    bg_alpha = int(round(255 * BAR_BG_ALPHA))
+
+    txt = f"Reps: {int(reps)}"
+    pad_x, pad_y = 10, 6
+    tmp = ImageDraw.Draw(Image.new("RGBA", (1, 1)))
+    tw = tmp.textlength(txt, font=REPS_FONT)
+    thh = REPS_FONT.size
+    cv2.rectangle(overlay_bgr, (0, 0), (int(tw + 2 * pad_x), int(thh + 2 * pad_y)), (0, 0, 0), -1)
+    cv2.rectangle(overlay_a, (0, 0), (int(tw + 2 * pad_x), int(thh + 2 * pad_y)), bg_alpha, -1)
+
+    cv2.circle(overlay_bgr, (cx, cy), r, DEPTH_RING_BG, th, cv2.LINE_AA)
+    cv2.circle(overlay_a, (cx, cy), r, 255, th, cv2.LINE_AA)
+    cv2.ellipse(overlay_bgr, (cx, cy), (r, r), 0, -90, -90 + int(360 * pct), DEPTH_COLOR, th, cv2.LINE_AA)
+    cv2.ellipse(overlay_a, (cx, cy), (r, r), 0, -90, -90 + int(360 * pct), 255, th, cv2.LINE_AA)
+
+    pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+    pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+    pil = Image.fromarray(pil_rgba)
+    draw = ImageDraw.Draw(pil)
+    draw.text((pad_x, pad_y - 1), txt, font=REPS_FONT, fill=(255, 255, 255, 255))
+
+    gap = max(2, int(r * 0.10))
+    by = cy - (DEPTH_LABEL_FONT.size + gap + DEPTH_PCT_FONT.size) // 2
+    label = "DEPTH"
+    pct_txt = f"{int(pct * 100)}%"
+    lw = draw.textlength(label, font=DEPTH_LABEL_FONT)
+    pw = draw.textlength(pct_txt, font=DEPTH_PCT_FONT)
+    draw.text((cx - int(lw // 2), by), label, font=DEPTH_LABEL_FONT, fill=(255, 255, 255, 255))
+    draw.text((cx - int(pw // 2), by + DEPTH_LABEL_FONT.size + gap), pct_txt, font=DEPTH_PCT_FONT, fill=(255, 255, 255, 255))
 
     if feedback:
-        max_w=int(w-2*12-20); lines=_wrap_two_lines(draw,feedback,FEEDBACK_FONT,max_w)
-        line_h=FEEDBACK_FONT.size+6
-        block_h=2*8+len(lines)*line_h+(len(lines)-1)*4
-        y0=max(0,h-max(6,int(h*0.02))-block_h); y1=h-max(6,int(h*0.02))
-        base2=np.array(pil); over2=base2.copy()
-        cv2.rectangle(over2,(0,y0),(w,y1),(0,0,0),-1)
-        base2=cv2.addWeighted(over2,BAR_BG_ALPHA,base2,1-BAR_BG_ALPHA,0)
-        pil=Image.fromarray(base2); draw=ImageDraw.Draw(pil)
-        ty=y0+8
+        max_w = int(HD_W - 2 * 12 - 20)
+        lines = _wrap_two_lines(draw, feedback, FEEDBACK_FONT, max_w)
+        line_h = FEEDBACK_FONT.size + 6
+        block_h = 2 * 8 + len(lines) * line_h + (len(lines) - 1) * 4
+        y0 = max(0, HD_H - max(6, int(HD_H * 0.02)) - block_h)
+        y1 = HD_H - max(6, int(HD_H * 0.02))
+        cv2.rectangle(overlay_bgr, (0, y0), (HD_W, y1), (0, 0, 0), -1)
+        cv2.rectangle(overlay_a, (0, y0), (HD_W, y1), bg_alpha, -1)
+
+        pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+        pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+        pil = Image.fromarray(pil_rgba)
+        draw = ImageDraw.Draw(pil)
+        ty = y0 + 8
         for ln in lines:
-            tw2=draw.textlength(ln,font=FEEDBACK_FONT); tx=max(12,(w-int(tw2))//2)
-            draw.text((tx,ty),ln,font=FEEDBACK_FONT,fill=(255,255,255)); ty+=line_h+4
-    return cv2.cvtColor(np.array(pil),cv2.COLOR_RGB2BGR)
+            tw2 = draw.textlength(ln, font=FEEDBACK_FONT)
+            tx = max(12, (HD_W - int(tw2)) // 2)
+            draw.text((tx, ty), ln, font=FEEDBACK_FONT, fill=(255, 255, 255, 255))
+            ty += line_h + 4
+
+    overlay_rgba = np.array(pil)
+    overlay_small = cv2.resize(overlay_rgba, (w, h), interpolation=cv2.INTER_AREA)
+    alpha = overlay_small[:, :, 3:4].astype(np.float32) / 255.0
+    rgb = cv2.cvtColor(overlay_small[:, :, :3], cv2.COLOR_RGB2BGR).astype(np.float32)
+    out = frame.astype(np.float32) * (1.0 - alpha) + rgb * alpha
+    return out.astype(np.uint8)
 
 # ============ IMPROVED Motion Detection - better for fast speeds ============
 BASE_FRAME_SKIP = 2

--- a/romanian_deadlift_analysis.py
+++ b/romanian_deadlift_analysis.py
@@ -116,94 +116,106 @@ def draw_depth_donut(frame, center, radius, thickness, pct):
 def draw_overlay(frame, reps=0, feedback=None, depth_pct=0.0):
     """Reps בפינת שמאל-עליון; דונאט ימני-עליון; פידבק תחתון — זהה לסקוואט."""
     h, w, _ = frame.shape
+    HD_H = 1080
+    hd_scale = HD_H / float(h)
+    HD_W = max(1, int(round(w * hd_scale)))
 
-    # --- Reps box (top-left) ---
-    pil = Image.fromarray(frame)
-    draw = ImageDraw.Draw(pil)
-    reps_text = f"Reps: {reps}"
-    inner_pad_x, inner_pad_y = 10, 6
-    text_w = draw.textlength(reps_text, font=REPS_FONT)
-    text_h = REPS_FONT.size
-    x0, y0 = 0, 0
-    x1 = int(text_w + 2 * inner_pad_x)
-    y1 = int(text_h + 2 * inner_pad_y)
-    top = frame.copy()
-    cv2.rectangle(top, (x0, y0), (x1, y1), (0, 0, 0), -1)
-    frame = cv2.addWeighted(top, BAR_BG_ALPHA, frame, 1.0 - BAR_BG_ALPHA, 0)
-    pil = Image.fromarray(frame)
-    ImageDraw.Draw(pil).text((x0 + inner_pad_x, y0 + inner_pad_y - 1),
-                             reps_text, font=REPS_FONT, fill=(255, 255, 255))
-    frame = np.array(pil)
-
-    # --- Donut (top-right) ---
-    ref_h = max(int(h * 0.06), int(REPS_FONT_SIZE * 1.6))
+    pct = float(np.clip(depth_pct, 0, 1))
+    ref_h = max(int(HD_H * 0.06), int(REPS_FONT_SIZE * 1.6))
     radius = int(ref_h * DONUT_RADIUS_SCALE)
     thick = max(3, int(radius * DONUT_THICKNESS_FRAC))
     margin = 12
-    cx = w - margin - radius
+    cx = HD_W - margin - radius
     cy = max(ref_h + radius // 8, radius + thick // 2 + 2)
-    frame = draw_depth_donut(frame, (cx, cy), radius, thick, float(np.clip(depth_pct, 0, 1)))
 
-    pil = Image.fromarray(frame)
+    overlay_bgr = np.zeros((HD_H, HD_W, 3), dtype=np.uint8)
+    overlay_a = np.zeros((HD_H, HD_W), dtype=np.uint8)
+    bg_alpha = int(round(255 * BAR_BG_ALPHA))
+
+    reps_text = f"Reps: {reps}"
+    inner_pad_x, inner_pad_y = 10, 6
+    tmp = ImageDraw.Draw(Image.new("RGBA", (1, 1)))
+    text_w = tmp.textlength(reps_text, font=REPS_FONT)
+    text_h = REPS_FONT.size
+    cv2.rectangle(overlay_bgr, (0, 0), (int(text_w + 2 * inner_pad_x), int(text_h + 2 * inner_pad_y)), (0, 0, 0), -1)
+    cv2.rectangle(overlay_a, (0, 0), (int(text_w + 2 * inner_pad_x), int(text_h + 2 * inner_pad_y)), bg_alpha, -1)
+
+    cv2.circle(overlay_bgr, (cx, cy), radius, DEPTH_RING_BG, thick, cv2.LINE_AA)
+    cv2.circle(overlay_a, (cx, cy), radius, 255, thick, cv2.LINE_AA)
+    start_ang = -90
+    end_ang = start_ang + int(360 * pct)
+    cv2.ellipse(overlay_bgr, (cx, cy), (radius, radius), 0, start_ang, end_ang, DEPTH_COLOR, thick, lineType=cv2.LINE_AA)
+    cv2.ellipse(overlay_a, (cx, cy), (radius, radius), 0, start_ang, end_ang, 255, thick, lineType=cv2.LINE_AA)
+
+    pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+    pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+    pil = Image.fromarray(pil_rgba)
     draw = ImageDraw.Draw(pil)
+    draw.text((inner_pad_x, inner_pad_y - 1), reps_text, font=REPS_FONT, fill=(255, 255, 255, 255))
+
     label_txt = "DEPTH"
-    pct_txt = f"{int(float(np.clip(depth_pct, 0, 1)) * 100)}%"
+    pct_txt = f"{int(pct * 100)}%"
     label_w = draw.textlength(label_txt, font=DEPTH_LABEL_FONT)
     pct_w = draw.textlength(pct_txt, font=DEPTH_PCT_FONT)
     gap = max(2, int(radius * 0.10))
     base_y = cy - (DEPTH_LABEL_FONT.size + gap + DEPTH_PCT_FONT.size) // 2
-    draw.text((cx - int(label_w // 2), base_y), label_txt, font=DEPTH_LABEL_FONT, fill=(255, 255, 255))
-    draw.text((cx - int(pct_w // 2), base_y + DEPTH_LABEL_FONT.size + gap),
-              pct_txt, font=DEPTH_PCT_FONT, fill=(255, 255, 255))
-    frame = np.array(pil)
+    draw.text((cx - int(label_w // 2), base_y), label_txt, font=DEPTH_LABEL_FONT, fill=(255, 255, 255, 255))
+    draw.text((cx - int(pct_w // 2), base_y + DEPTH_LABEL_FONT.size + gap), pct_txt, font=DEPTH_PCT_FONT, fill=(255, 255, 255, 255))
 
-    # --- Bottom feedback ---
     if feedback:
-        def wrap_to_two_lines(draw, text, font, max_width):
+        def wrap_to_two_lines(draw_obj, text, font, max_width):
             words = text.split()
-            if not words: return [""]
+            if not words:
+                return [""]
             lines, cur = [], ""
-            for w in words:
-                trial = (cur + " " + w).strip()
-                if draw.textlength(trial, font=font) <= max_width:
+            for word in words:
+                trial = (cur + " " + word).strip()
+                if draw_obj.textlength(trial, font=font) <= max_width:
                     cur = trial
                 else:
-                    if cur: lines.append(cur)
-                    cur = w
-                if len(lines) == 2: break
-            if cur and len(lines) < 2: lines.append(cur)
-            leftover = len(words) - sum(len(l.split()) for l in lines)
+                    if cur:
+                        lines.append(cur)
+                    cur = word
+                if len(lines) == 2:
+                    break
+            if cur and len(lines) < 2:
+                lines.append(cur)
+            leftover = len(words) - sum(len(line.split()) for line in lines)
             if leftover > 0 and len(lines) >= 2:
                 last = lines[-1] + "…"
-                while draw.textlength(last, font=font) > max_width and len(last) > 1:
+                while draw_obj.textlength(last, font=font) > max_width and len(last) > 1:
                     last = last[:-2] + "…"
                 lines[-1] = last
             return lines
 
-        pil_fb = Image.fromarray(frame)
-        draw_fb = ImageDraw.Draw(pil_fb)
-        safe_margin = max(6, int(h * 0.02))
+        safe_margin = max(6, int(HD_H * 0.02))
         pad_x, pad_y, line_gap = 12, 8, 4
-        max_text_w = int(w - 2 * pad_x - 20)
-        lines = wrap_to_two_lines(draw_fb, feedback, FEEDBACK_FONT, max_text_w)
+        max_text_w = int(HD_W - 2 * pad_x - 20)
+        lines = wrap_to_two_lines(draw, feedback, FEEDBACK_FONT, max_text_w)
         line_h = FEEDBACK_FONT.size + 6
         block_h = (2 * pad_y) + len(lines) * line_h + (len(lines) - 1) * line_gap
-        y0 = max(0, h - safe_margin - block_h)
-        y1 = h - safe_margin
-        over = frame.copy()
-        cv2.rectangle(over, (0, y0), (w, y1), (0, 0, 0), -1)
-        frame = cv2.addWeighted(over, BAR_BG_ALPHA, frame, 1.0 - BAR_BG_ALPHA, 0)
-        pil_fb = Image.fromarray(frame)
-        draw_fb = ImageDraw.Draw(pil_fb)
+        y0 = max(0, HD_H - safe_margin - block_h)
+        y1 = HD_H - safe_margin
+        cv2.rectangle(overlay_bgr, (0, y0), (HD_W, y1), (0, 0, 0), -1)
+        cv2.rectangle(overlay_a, (0, y0), (HD_W, y1), bg_alpha, -1)
+
+        pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+        pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+        pil = Image.fromarray(pil_rgba)
+        draw = ImageDraw.Draw(pil)
         ty = y0 + pad_y
         for ln in lines:
-            tw = draw_fb.textlength(ln, font=FEEDBACK_FONT)
-            tx = max(pad_x, (w - int(tw)) // 2)
-            draw_fb.text((tx, ty), ln, font=FEEDBACK_FONT, fill=(255, 255, 255))
+            tw = draw.textlength(ln, font=FEEDBACK_FONT)
+            tx = max(pad_x, (HD_W - int(tw)) // 2)
+            draw.text((tx, ty), ln, font=FEEDBACK_FONT, fill=(255, 255, 255, 255))
             ty += line_h + line_gap
-        frame = np.array(pil_fb)
 
-    return frame
+    overlay_rgba = np.array(pil)
+    overlay_small = cv2.resize(overlay_rgba, (w, h), interpolation=cv2.INTER_AREA)
+    alpha = overlay_small[:, :, 3:4].astype(np.float32) / 255.0
+    rgb = cv2.cvtColor(overlay_small[:, :, :3], cv2.COLOR_RGB2BGR).astype(np.float32)
+    out = frame.astype(np.float32) * (1.0 - alpha) + rgb * alpha
+    return out.astype(np.uint8)
 
 # ===================== GEOMETRY =====================
 def angle_deg(a, b, c):

--- a/squat_analysis.py
+++ b/squat_analysis.py
@@ -107,90 +107,106 @@ def draw_depth_donut(frame, center, radius, thickness, pct):
 def draw_overlay(frame, reps=0, feedback=None, depth_pct=0.0):
     """Reps בפינת שמאל-עליון; דונאט ימני-עליון; פידבק תחתון"""
     h, w, _ = frame.shape
+    HD_H = 1080
+    hd_scale = HD_H / float(h)
+    HD_W = max(1, int(round(w * hd_scale)))
 
-    # --- Reps box ---
-    pil = Image.fromarray(frame)
-    draw = ImageDraw.Draw(pil)
+    pct = float(np.clip(depth_pct, 0, 1))
+    ref_h = max(int(HD_H * 0.06), int(REPS_FONT_SIZE * 1.6))
+    radius = int(ref_h * DONUT_RADIUS_SCALE)
+    thick = max(3, int(radius * DONUT_THICKNESS_FRAC))
+    margin = 12
+    cx = HD_W - margin - radius
+    cy = max(ref_h + radius // 8, radius + thick // 2 + 2)
+
+    overlay_bgr = np.zeros((HD_H, HD_W, 3), dtype=np.uint8)
+    overlay_a = np.zeros((HD_H, HD_W), dtype=np.uint8)
+    bg_alpha = int(round(255 * BAR_BG_ALPHA))
+
     reps_text = f"Reps: {reps}"
     inner_pad_x, inner_pad_y = 10, 6
-    text_w = draw.textlength(reps_text, font=REPS_FONT)
+    tmp = ImageDraw.Draw(Image.new("RGBA", (1, 1)))
+    text_w = tmp.textlength(reps_text, font=REPS_FONT)
     text_h = REPS_FONT.size
-    x0, y0 = 0, 0
-    x1 = int(text_w + 2*inner_pad_x)
-    y1 = int(text_h + 2*inner_pad_y)
-    top = frame.copy()
-    cv2.rectangle(top, (x0, y0), (x1, y1), (0, 0, 0), -1)
-    frame = cv2.addWeighted(top, BAR_BG_ALPHA, frame, 1.0 - BAR_BG_ALPHA, 0)
-    pil = Image.fromarray(frame)
-    ImageDraw.Draw(pil).text((x0 + inner_pad_x, y0 + inner_pad_y - 1),
-                             reps_text, font=REPS_FONT, fill=(255, 255, 255))
-    frame = np.array(pil)
+    cv2.rectangle(overlay_bgr, (0, 0), (int(text_w + 2 * inner_pad_x), int(text_h + 2 * inner_pad_y)), (0, 0, 0), -1)
+    cv2.rectangle(overlay_a, (0, 0), (int(text_w + 2 * inner_pad_x), int(text_h + 2 * inner_pad_y)), bg_alpha, -1)
 
-    # --- Donut ---
-    ref_h = max(int(h * 0.06), int(REPS_FONT_SIZE * 1.6))
-    radius = int(ref_h * DONUT_RADIUS_SCALE)
-    thick  = max(3, int(radius * DONUT_THICKNESS_FRAC))
-    margin = 12
-    cx = w - margin - radius
-    cy = max(ref_h + radius // 8, radius + thick // 2 + 2)
-    frame = draw_depth_donut(frame, (cx, cy), radius, thick, float(np.clip(depth_pct,0,1)))
+    cv2.circle(overlay_bgr, (cx, cy), radius, DEPTH_RING_BG, thick, cv2.LINE_AA)
+    cv2.circle(overlay_a, (cx, cy), radius, 255, thick, cv2.LINE_AA)
+    start_ang = -90
+    end_ang = start_ang + int(360 * pct)
+    cv2.ellipse(overlay_bgr, (cx, cy), (radius, radius), 0, start_ang, end_ang, DEPTH_COLOR, thick, lineType=cv2.LINE_AA)
+    cv2.ellipse(overlay_a, (cx, cy), (radius, radius), 0, start_ang, end_ang, 255, thick, lineType=cv2.LINE_AA)
 
-    pil  = Image.fromarray(frame)
+    pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+    pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+    pil = Image.fromarray(pil_rgba)
     draw = ImageDraw.Draw(pil)
-    label_txt = "DEPTH"; pct_txt = f"{int(float(np.clip(depth_pct,0,1))*100)}%"
-    label_w = draw.textlength(label_txt, font=DEPTH_LABEL_FONT)
-    pct_w   = draw.textlength(pct_txt,   font=DEPTH_PCT_FONT)
-    gap     = max(2, int(radius * 0.10))
-    base_y  = cy - (DEPTH_LABEL_FONT.size + gap + DEPTH_PCT_FONT.size) // 2
-    draw.text((cx - int(label_w // 2), base_y), label_txt, font=DEPTH_LABEL_FONT, fill=(255,255,255))
-    draw.text((cx - int(pct_w // 2), base_y + DEPTH_LABEL_FONT.size + gap),
-              pct_txt, font=DEPTH_PCT_FONT, fill=(255,255,255))
-    frame = np.array(pil)
+    draw.text((inner_pad_x, inner_pad_y - 1), reps_text, font=REPS_FONT, fill=(255, 255, 255, 255))
 
-    # --- Bottom feedback ---
+    label_txt = "DEPTH"
+    pct_txt = f"{int(pct * 100)}%"
+    label_w = draw.textlength(label_txt, font=DEPTH_LABEL_FONT)
+    pct_w = draw.textlength(pct_txt, font=DEPTH_PCT_FONT)
+    gap = max(2, int(radius * 0.10))
+    base_y = cy - (DEPTH_LABEL_FONT.size + gap + DEPTH_PCT_FONT.size) // 2
+    draw.text((cx - int(label_w // 2), base_y), label_txt, font=DEPTH_LABEL_FONT, fill=(255, 255, 255, 255))
+    draw.text((cx - int(pct_w // 2), base_y + DEPTH_LABEL_FONT.size + gap), pct_txt, font=DEPTH_PCT_FONT, fill=(255, 255, 255, 255))
+
     if feedback:
-        def wrap_to_two_lines(draw, text, font, max_width):
+        def wrap_to_two_lines(draw_obj, text, font, max_width):
             words = text.split()
-            if not words: return [""]
+            if not words:
+                return [""]
             lines, cur = [], ""
-            for w in words:
-                trial = (cur + " " + w).strip()
-                if draw.textlength(trial, font=font) <= max_width:
+            for word in words:
+                trial = (cur + " " + word).strip()
+                if draw_obj.textlength(trial, font=font) <= max_width:
                     cur = trial
                 else:
-                    if cur: lines.append(cur)
-                    cur = w
-                if len(lines) == 2: break
-            if cur and len(lines) < 2: lines.append(cur)
-            leftover = len(words) - sum(len(l.split()) for l in lines)
+                    if cur:
+                        lines.append(cur)
+                    cur = word
+                if len(lines) == 2:
+                    break
+            if cur and len(lines) < 2:
+                lines.append(cur)
+            leftover = len(words) - sum(len(line.split()) for line in lines)
             if leftover > 0 and len(lines) >= 2:
                 last = lines[-1] + "…"
-                while draw.textlength(last, font=font) > max_width and len(last) > 1:
+                while draw_obj.textlength(last, font=font) > max_width and len(last) > 1:
                     last = last[:-2] + "…"
                 lines[-1] = last
             return lines
 
-        pil_fb = Image.fromarray(frame); draw_fb = ImageDraw.Draw(pil_fb)
-        safe_margin = max(6, int(h * 0.02))
+        safe_margin = max(6, int(HD_H * 0.02))
         pad_x, pad_y, line_gap = 12, 8, 4
-        max_text_w = int(w - 2*pad_x - 20)
-        lines = wrap_to_two_lines(draw_fb, feedback, FEEDBACK_FONT, max_text_w)
+        max_text_w = int(HD_W - 2 * pad_x - 20)
+        lines = wrap_to_two_lines(draw, feedback, FEEDBACK_FONT, max_text_w)
         line_h = FEEDBACK_FONT.size + 6
-        block_h = (2*pad_y) + len(lines)*line_h + (len(lines)-1)*line_gap
-        y0 = max(0, h - safe_margin - block_h); y1 = h - safe_margin
-        over = frame.copy()
-        cv2.rectangle(over, (0, y0), (w, y1), (0,0,0), -1)
-        frame = cv2.addWeighted(over, BAR_BG_ALPHA, frame, 1.0 - BAR_BG_ALPHA, 0)
-        pil_fb = Image.fromarray(frame); draw_fb = ImageDraw.Draw(pil_fb)
+        block_h = (2 * pad_y) + len(lines) * line_h + (len(lines) - 1) * line_gap
+        y0 = max(0, HD_H - safe_margin - block_h)
+        y1 = HD_H - safe_margin
+        cv2.rectangle(overlay_bgr, (0, y0), (HD_W, y1), (0, 0, 0), -1)
+        cv2.rectangle(overlay_a, (0, y0), (HD_W, y1), bg_alpha, -1)
+
+        pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+        pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+        pil = Image.fromarray(pil_rgba)
+        draw = ImageDraw.Draw(pil)
         ty = y0 + pad_y
         for ln in lines:
-            tw = draw_fb.textlength(ln, font=FEEDBACK_FONT)
-            tx = max(pad_x, (w - int(tw)) // 2)
-            draw_fb.text((tx, ty), ln, font=FEEDBACK_FONT, fill=(255,255,255))
+            tw = draw.textlength(ln, font=FEEDBACK_FONT)
+            tx = max(pad_x, (HD_W - int(tw)) // 2)
+            draw.text((tx, ty), ln, font=FEEDBACK_FONT, fill=(255, 255, 255, 255))
             ty += line_h + line_gap
-        frame = np.array(pil_fb)
 
-    return frame
+    overlay_rgba = np.array(pil)
+    overlay_small = cv2.resize(overlay_rgba, (w, h), interpolation=cv2.INTER_AREA)
+    alpha = overlay_small[:, :, 3:4].astype(np.float32) / 255.0
+    rgb = cv2.cvtColor(overlay_small[:, :, :3], cv2.COLOR_RGB2BGR).astype(np.float32)
+    out = frame.astype(np.float32) * (1.0 - alpha) + rgb * alpha
+    return out.astype(np.uint8)
 
 # ===================== BODY-ONLY SKELETON =====================
 _FACE_LMS = {

--- a/stiff_leg_deadlift_analysis.py
+++ b/stiff_leg_deadlift_analysis.py
@@ -112,94 +112,106 @@ def draw_depth_donut(frame, center, radius, thickness, pct):
 def draw_overlay(frame, reps=0, feedback=None, depth_pct=0.0):
     """Reps בפינת שמאל-עליון; דונאט ימני-עליון; פידבק תחתון — זהה לסקוואט."""
     h, w, _ = frame.shape
+    HD_H = 1080
+    hd_scale = HD_H / float(h)
+    HD_W = max(1, int(round(w * hd_scale)))
 
-    # --- Reps box (top-left) ---
-    pil = Image.fromarray(frame)
-    draw = ImageDraw.Draw(pil)
-    reps_text = f"Reps: {reps}"
-    inner_pad_x, inner_pad_y = 10, 6
-    text_w = draw.textlength(reps_text, font=REPS_FONT)
-    text_h = REPS_FONT.size
-    x0, y0 = 0, 0
-    x1 = int(text_w + 2 * inner_pad_x)
-    y1 = int(text_h + 2 * inner_pad_y)
-    top = frame.copy()
-    cv2.rectangle(top, (x0, y0), (x1, y1), (0, 0, 0), -1)
-    frame = cv2.addWeighted(top, BAR_BG_ALPHA, frame, 1.0 - BAR_BG_ALPHA, 0)
-    pil = Image.fromarray(frame)
-    ImageDraw.Draw(pil).text((x0 + inner_pad_x, y0 + inner_pad_y - 1),
-                             reps_text, font=REPS_FONT, fill=(255, 255, 255))
-    frame = np.array(pil)
-
-    # --- Donut (top-right) ---
-    ref_h = max(int(h * 0.06), int(REPS_FONT_SIZE * 1.6))
+    pct = float(np.clip(depth_pct, 0, 1))
+    ref_h = max(int(HD_H * 0.06), int(REPS_FONT_SIZE * 1.6))
     radius = int(ref_h * DONUT_RADIUS_SCALE)
     thick = max(3, int(radius * DONUT_THICKNESS_FRAC))
     margin = 12
-    cx = w - margin - radius
+    cx = HD_W - margin - radius
     cy = max(ref_h + radius // 8, radius + thick // 2 + 2)
-    frame = draw_depth_donut(frame, (cx, cy), radius, thick, float(np.clip(depth_pct, 0, 1)))
 
-    pil = Image.fromarray(frame)
+    overlay_bgr = np.zeros((HD_H, HD_W, 3), dtype=np.uint8)
+    overlay_a = np.zeros((HD_H, HD_W), dtype=np.uint8)
+    bg_alpha = int(round(255 * BAR_BG_ALPHA))
+
+    reps_text = f"Reps: {reps}"
+    inner_pad_x, inner_pad_y = 10, 6
+    tmp = ImageDraw.Draw(Image.new("RGBA", (1, 1)))
+    text_w = tmp.textlength(reps_text, font=REPS_FONT)
+    text_h = REPS_FONT.size
+    cv2.rectangle(overlay_bgr, (0, 0), (int(text_w + 2 * inner_pad_x), int(text_h + 2 * inner_pad_y)), (0, 0, 0), -1)
+    cv2.rectangle(overlay_a, (0, 0), (int(text_w + 2 * inner_pad_x), int(text_h + 2 * inner_pad_y)), bg_alpha, -1)
+
+    cv2.circle(overlay_bgr, (cx, cy), radius, DEPTH_RING_BG, thick, cv2.LINE_AA)
+    cv2.circle(overlay_a, (cx, cy), radius, 255, thick, cv2.LINE_AA)
+    start_ang = -90
+    end_ang = start_ang + int(360 * pct)
+    cv2.ellipse(overlay_bgr, (cx, cy), (radius, radius), 0, start_ang, end_ang, DEPTH_COLOR, thick, lineType=cv2.LINE_AA)
+    cv2.ellipse(overlay_a, (cx, cy), (radius, radius), 0, start_ang, end_ang, 255, thick, lineType=cv2.LINE_AA)
+
+    pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+    pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+    pil = Image.fromarray(pil_rgba)
     draw = ImageDraw.Draw(pil)
+    draw.text((inner_pad_x, inner_pad_y - 1), reps_text, font=REPS_FONT, fill=(255, 255, 255, 255))
+
     label_txt = "DEPTH"
-    pct_txt = f"{int(float(np.clip(depth_pct, 0, 1)) * 100)}%"
+    pct_txt = f"{int(pct * 100)}%"
     label_w = draw.textlength(label_txt, font=DEPTH_LABEL_FONT)
     pct_w = draw.textlength(pct_txt, font=DEPTH_PCT_FONT)
     gap = max(2, int(radius * 0.10))
     base_y = cy - (DEPTH_LABEL_FONT.size + gap + DEPTH_PCT_FONT.size) // 2
-    draw.text((cx - int(label_w // 2), base_y), label_txt, font=DEPTH_LABEL_FONT, fill=(255, 255, 255))
-    draw.text((cx - int(pct_w // 2), base_y + DEPTH_LABEL_FONT.size + gap),
-              pct_txt, font=DEPTH_PCT_FONT, fill=(255, 255, 255))
-    frame = np.array(pil)
+    draw.text((cx - int(label_w // 2), base_y), label_txt, font=DEPTH_LABEL_FONT, fill=(255, 255, 255, 255))
+    draw.text((cx - int(pct_w // 2), base_y + DEPTH_LABEL_FONT.size + gap), pct_txt, font=DEPTH_PCT_FONT, fill=(255, 255, 255, 255))
 
-    # --- Bottom feedback ---
     if feedback:
-        def wrap_to_two_lines(draw, text, font, max_width):
+        def wrap_to_two_lines(draw_obj, text, font, max_width):
             words = text.split()
-            if not words: return [""]
+            if not words:
+                return [""]
             lines, cur = [], ""
-            for w in words:
-                trial = (cur + " " + w).strip()
-                if draw.textlength(trial, font=font) <= max_width:
+            for word in words:
+                trial = (cur + " " + word).strip()
+                if draw_obj.textlength(trial, font=font) <= max_width:
                     cur = trial
                 else:
-                    if cur: lines.append(cur)
-                    cur = w
-                if len(lines) == 2: break
-            if cur and len(lines) < 2: lines.append(cur)
-            leftover = len(words) - sum(len(l.split()) for l in lines)
+                    if cur:
+                        lines.append(cur)
+                    cur = word
+                if len(lines) == 2:
+                    break
+            if cur and len(lines) < 2:
+                lines.append(cur)
+            leftover = len(words) - sum(len(line.split()) for line in lines)
             if leftover > 0 and len(lines) >= 2:
                 last = lines[-1] + "…"
-                while draw.textlength(last, font=font) > max_width and len(last) > 1:
+                while draw_obj.textlength(last, font=font) > max_width and len(last) > 1:
                     last = last[:-2] + "…"
                 lines[-1] = last
             return lines
 
-        pil_fb = Image.fromarray(frame)
-        draw_fb = ImageDraw.Draw(pil_fb)
-        safe_margin = max(6, int(h * 0.02))
+        safe_margin = max(6, int(HD_H * 0.02))
         pad_x, pad_y, line_gap = 12, 8, 4
-        max_text_w = int(w - 2 * pad_x - 20)
-        lines = wrap_to_two_lines(draw_fb, feedback, FEEDBACK_FONT, max_text_w)
+        max_text_w = int(HD_W - 2 * pad_x - 20)
+        lines = wrap_to_two_lines(draw, feedback, FEEDBACK_FONT, max_text_w)
         line_h = FEEDBACK_FONT.size + 6
         block_h = (2 * pad_y) + len(lines) * line_h + (len(lines) - 1) * line_gap
-        y0 = max(0, h - safe_margin - block_h)
-        y1 = h - safe_margin
-        over = frame.copy()
-        cv2.rectangle(over, (0, y0), (w, y1), (0, 0, 0), -1)
-        frame = cv2.addWeighted(over, BAR_BG_ALPHA, frame, 1.0 - BAR_BG_ALPHA, 0)
-        pil_fb = Image.fromarray(frame)
-        draw_fb = ImageDraw.Draw(pil_fb)
+        y0 = max(0, HD_H - safe_margin - block_h)
+        y1 = HD_H - safe_margin
+        cv2.rectangle(overlay_bgr, (0, y0), (HD_W, y1), (0, 0, 0), -1)
+        cv2.rectangle(overlay_a, (0, y0), (HD_W, y1), bg_alpha, -1)
+
+        pil_rgba = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGBA)
+        pil_rgba[:, :, 3] = np.maximum(pil_rgba[:, :, 3], overlay_a)
+        pil = Image.fromarray(pil_rgba)
+        draw = ImageDraw.Draw(pil)
         ty = y0 + pad_y
         for ln in lines:
-            tw = draw_fb.textlength(ln, font=FEEDBACK_FONT)
-            tx = max(pad_x, (w - int(tw)) // 2)
-            draw_fb.text((tx, ty), ln, font=FEEDBACK_FONT, fill=(255, 255, 255))
+            tw = draw.textlength(ln, font=FEEDBACK_FONT)
+            tx = max(pad_x, (HD_W - int(tw)) // 2)
+            draw.text((tx, ty), ln, font=FEEDBACK_FONT, fill=(255, 255, 255, 255))
             ty += line_h + line_gap
-        frame = np.array(pil_fb)
 
-    return frame
+    overlay_rgba = np.array(pil)
+    overlay_small = cv2.resize(overlay_rgba, (w, h), interpolation=cv2.INTER_AREA)
+    alpha = overlay_small[:, :, 3:4].astype(np.float32) / 255.0
+    rgb = cv2.cvtColor(overlay_small[:, :, :3], cv2.COLOR_RGB2BGR).astype(np.float32)
+    out = frame.astype(np.float32) * (1.0 - alpha) + rgb * alpha
+    return out.astype(np.uint8)
 
 # ===================== GEOMETRY =====================
 def angle_deg(a, b, c):


### PR DESCRIPTION
### Motivation
- Overlays were being drawn directly on scaled-down frames which produced pixelated text and donut rings; the goal is to render UI at high resolution then downscale for clean anti-aliased output. 

### Description
- Reworked `draw_overlay` in all exercise analysis modules to create a fixed HD RGBA canvas (`HD_H = 1080`, `HD_W` proportional to frame aspect), draw all overlay elements (reps box, donut + label + percentage, bottom feedback bar) on that canvas, then downscale with `cv2.INTER_AREA` and alpha-composite onto the working frame. 
- Kept existing visual layout, colors, transparency (`BAR_BG_ALPHA`), fonts and placement identical; used PIL `ImageDraw` for text on the HD canvas and cv2 for shapes, taking care of RGB/BGR conversions. 
- For modules that use `_scaled_font_size`, font sizes are now computed against the HD canvas height (`1080`) to preserve proportional appearance at 1080p before downscaling. 
- Files updated: `pullup_analysis.py`, `good_morning_analysis.py`, `bent_over_row_analysis.py`, `squat_analysis.py`, `deadlift_analysis.py`, `stiff_leg_deadlift_analysis.py`, `romanian_deadlift_analysis.py`, `dips_analysis.py`, `pushup_analysis.py`, `bulgarian_split_squat_analysis.py`, and `overhead_press_analysis.py`.

### Testing
- Successfully type-checked/compiled the modified modules with `python -m py_compile pullup_analysis.py good_morning_analysis.py bent_over_row_analysis.py squat_analysis.py deadlift_analysis.py stiff_leg_deadlift_analysis.py romanian_deadlift_analysis.py dips_analysis.py pushup_analysis.py bulgarian_split_squat_analysis.py overhead_press_analysis.py`, which completed without errors. 
- Confirmed `def draw_overlay` now exists in each targeted file and the new HD rendering + downscale + alpha-composite code paths are present via repository scans.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d9f37c3f88323aceb90994ef8fa6e)