### PR TITLE
Cache overlay resources, handle video rotation, and tweak encoder preset

### DIFF
--- a/pullup_analysis.py
+++ b/pullup_analysis.py
@@ -2,7 +2,7 @@
 # pullup_analysis.py — SMART FORM_TIP edition with FAST/SLOW path optimization
 # form_tip = optimization advice (doesn't affect score, only helps improve)
 
-import os, cv2, math, numpy as np, subprocess
+import os, cv2, math, numpy as np, subprocess, json
 from collections import deque
 from PIL import ImageFont, ImageDraw, Image
 
@@ -16,12 +16,62 @@ _REF_FEEDBACK_FONT_SIZE = 22
 _REF_DEPTH_LABEL_FONT_SIZE = 14
 _REF_DEPTH_PCT_FONT_SIZE = 18
 
+# Cache overlay resources per output frame size to avoid expensive per-frame
+# font loading and constant geometry recalculation.
+_OVERLAY_CACHE = {}
+
 def _load_font(p,s):
     try: return ImageFont.truetype(p,s)
     except: return ImageFont.load_default()
 
 def _scaled_font_size(ref_size, canvas_h):
     return max(10, int(round(ref_size * (canvas_h / _REF_H))))
+
+def _get_overlay_cache(w, h):
+    key = (int(w), int(h))
+    cached = _OVERLAY_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    HD_H = 1080
+    hd_scale = HD_H / float(h)
+    HD_W = max(1, int(round(w * hd_scale)))
+
+    reps_font_size = _scaled_font_size(_REF_REPS_FONT_SIZE, HD_H)
+    feedback_font_size = _scaled_font_size(_REF_FEEDBACK_FONT_SIZE, HD_H)
+    depth_label_font_size = _scaled_font_size(_REF_DEPTH_LABEL_FONT_SIZE, HD_H)
+    depth_pct_font_size = _scaled_font_size(_REF_DEPTH_PCT_FONT_SIZE, HD_H)
+
+    reps_font = _load_font(FONT_PATH, reps_font_size)
+    feedback_font = _load_font(FONT_PATH, feedback_font_size)
+    depth_label_font = _load_font(FONT_PATH, depth_label_font_size)
+    depth_pct_font = _load_font(FONT_PATH, depth_pct_font_size)
+
+    ref_h = max(int(HD_H * 0.06), int(reps_font_size * 1.6))
+    radius = int(ref_h * DONUT_RADIUS_SCALE)
+    thick = max(3, int(radius * DONUT_THICKNESS_FRAC))
+    margin = int(12 * hd_scale)
+    cx = HD_W - margin - radius
+    cy = max(ref_h + radius // 8, radius + thick // 2 + 2)
+    pad_x, pad_y = int(10 * hd_scale), int(6 * hd_scale)
+
+    cache = {
+        "HD_H": HD_H,
+        "HD_W": HD_W,
+        "hd_scale": hd_scale,
+        "reps_font": reps_font,
+        "feedback_font": feedback_font,
+        "depth_label_font": depth_label_font,
+        "depth_pct_font": depth_pct_font,
+        "radius": radius,
+        "thick": thick,
+        "cx": cx,
+        "cy": cy,
+        "pad_x": pad_x,
+        "pad_y": pad_y,
+    }
+    _OVERLAY_CACHE[key] = cache
+    return cache
 
 # ============ MediaPipe ============
 try:
@@ -44,6 +94,71 @@ else:
 
 def _get_fast_pose():
     return _FAST_POSE
+
+# ============ Video orientation helpers ============
+def _read_video_rotation(video_path):
+    """Return normalized clockwise rotation in degrees (0/90/180/270)."""
+    try:
+        proc = subprocess.run(
+            [
+                "ffprobe", "-v", "error",
+                "-select_streams", "v:0",
+                "-show_entries", "stream_tags=rotate:stream_side_data=rotation",
+                "-of", "json",
+                video_path,
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        if proc.returncode != 0 or not proc.stdout:
+            return 0
+
+        data = json.loads(proc.stdout)
+        streams = data.get("streams") or []
+        if not streams:
+            return 0
+
+        st = streams[0] if isinstance(streams[0], dict) else {}
+        rot = None
+
+        tags = st.get("tags") if isinstance(st.get("tags"), dict) else {}
+        if "rotate" in tags:
+            try:
+                rot = int(float(tags["rotate"]))
+            except Exception:
+                rot = None
+
+        if rot is None:
+            for sd in (st.get("side_data_list") or []):
+                if not isinstance(sd, dict):
+                    continue
+                if "rotation" in sd:
+                    try:
+                        rot = int(float(sd["rotation"]))
+                        break
+                    except Exception:
+                        pass
+
+        if rot is None:
+            return 0
+
+        # ffprobe rotation may be negative; convert to clockwise canonical [0, 360).
+        rot = rot % 360
+        closest = min((0, 90, 180, 270), key=lambda x: abs(x - rot))
+        return int(closest)
+    except Exception:
+        return 0
+
+def _rotate_frame_clockwise(frame, degrees):
+    if degrees == 90:
+        return cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
+    if degrees == 180:
+        return cv2.rotate(frame, cv2.ROTATE_180)
+    if degrees == 270:
+        return cv2.rotate(frame, cv2.ROTATE_90_COUNTERCLOCKWISE)
+    return frame
 
 # ============ Helpers ============
 def _ang(a,b,c):
@@ -115,33 +230,27 @@ def draw_body_only(frame, lms, color=(255,255,255)):
 
 def draw_overlay(frame, reps=0, feedback=None, height_pct=0.0):
     h, w, _ = frame.shape
-    HD_H = 1080
-    hd_scale = HD_H / float(h)
-    HD_W = max(1, int(round(w * hd_scale)))
-
-    reps_font_size = _scaled_font_size(_REF_REPS_FONT_SIZE, HD_H)
-    feedback_font_size = _scaled_font_size(_REF_FEEDBACK_FONT_SIZE, HD_H)
-    depth_label_font_size = _scaled_font_size(_REF_DEPTH_LABEL_FONT_SIZE, HD_H)
-    depth_pct_font_size = _scaled_font_size(_REF_DEPTH_PCT_FONT_SIZE, HD_H)
-
-    _REPS_FONT = _load_font(FONT_PATH, reps_font_size)
-    _FEEDBACK_FONT = _load_font(FONT_PATH, feedback_font_size)
-    _DEPTH_LABEL_FONT = _load_font(FONT_PATH, depth_label_font_size)
-    _DEPTH_PCT_FONT = _load_font(FONT_PATH, depth_pct_font_size)
+    cache = _get_overlay_cache(w, h)
+    HD_H = cache["HD_H"]
+    HD_W = cache["HD_W"]
+    hd_scale = cache["hd_scale"]
+    _REPS_FONT = cache["reps_font"]
+    _FEEDBACK_FONT = cache["feedback_font"]
+    _DEPTH_LABEL_FONT = cache["depth_label_font"]
+    _DEPTH_PCT_FONT = cache["depth_pct_font"]
 
     pct = float(np.clip(height_pct, 0, 1))
     bg_alpha_val = int(round(255 * BAR_BG_ALPHA))
 
-    ref_h = max(int(HD_H * 0.06), int(reps_font_size * 1.6))
-    radius = int(ref_h * DONUT_RADIUS_SCALE)
-    thick = max(3, int(radius * DONUT_THICKNESS_FRAC))
-    margin = int(12 * hd_scale)
-    cx = HD_W - margin - radius
-    cy = max(ref_h + radius // 8, radius + thick // 2 + 2)
+    radius = cache["radius"]
+    thick = cache["thick"]
+    cx = cache["cx"]
+    cy = cache["cy"]
 
     overlay_np = np.zeros((HD_H, HD_W, 4), dtype=np.uint8)
 
-    pad_x, pad_y = int(10 * hd_scale), int(6 * hd_scale)
+    pad_x = cache["pad_x"]
+    pad_y = cache["pad_y"]
     tmp_pil = Image.new("RGBA", (1, 1))
     tmp_draw = ImageDraw.Draw(tmp_pil)
     txt = f"Reps: {int(reps)}"
@@ -313,6 +422,10 @@ def run_pullup_analysis(video_path,
     cap=cv2.VideoCapture(video_path)
     if not cap.isOpened(): return _ret_err("Could not open video", feedback_path)
 
+    source_rotation = _read_video_rotation(video_path)
+    apply_rotation = False
+    rotation_checked = False
+
     fps_in=cap.get(cv2.CAP_PROP_FPS) or 25
     effective_fps=max(1.0, fps_in/max(1,effective_frame_skip))
     sec_to_frames=lambda s: max(1,int(s*effective_fps))
@@ -407,7 +520,19 @@ def run_pullup_analysis(video_path,
             
             if burst_cntr > 0:
                 burst_cntr -= 1
-            
+
+            if not rotation_checked:
+                # Apply 90/270 only when source is likely stored sideways (landscape buffers).
+                # We intentionally avoid forced 180 rotation: some decoders already apply
+                # 180 orientation and rotating again flips the analyzed output upside-down.
+                if source_rotation in (90, 270):
+                    h0, w0 = frame.shape[:2]
+                    apply_rotation = (w0 > h0)
+                rotation_checked = True
+
+            if apply_rotation and source_rotation:
+                frame = _rotate_frame_clockwise(frame, source_rotation)
+
             processed_frame_count += 1
 
             # Resize frame (for both paths, affects pose detection)
@@ -813,7 +938,7 @@ def run_pullup_analysis(video_path,
     if slow_path and os.path.exists(output_path):
         encoded_path=output_path.replace(".mp4","_encoded.mp4")
         try:
-            subprocess.run(["ffmpeg","-y","-i",output_path,"-c:v","libx264","-preset","medium",
+            subprocess.run(["ffmpeg","-y","-i",output_path,"-c:v","libx264","-preset","fast",
                             "-crf",str(int(encode_crf if encode_crf is not None else 23)),"-movflags","+faststart","-pix_fmt","yuv420p",
                             encoded_path], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             final_path=encoded_path if os.path.exists(encoded_path) else output_path


### PR DESCRIPTION
### Motivation
- Avoid expensive per-frame font loading and repeated geometry computation for overlays to improve performance and reduce CPU load. 
- Correctly handle videos that have rotation metadata so pose analysis and overlays are applied to frames with the intended orientation. 
- Improve output encoding speed by adjusting the ffmpeg preset.

### Description
- Add an `_OVERLAY_CACHE` and `_get_overlay_cache(w,h)` to precompute and cache fonts, sizing, and overlay geometry for a given output size and reuse them in `draw_overlay` instead of creating fonts per-frame. 
- Add `_read_video_rotation(video_path)` (uses `ffprobe`) and `_rotate_frame_clockwise(frame,degrees)` helpers and apply rotation once per source when needed for `90`/`270` degree tags; only rotate when the source buffer orientation suggests it's required. 
- Import `json` and wire rotation detection into the main `run_pullup_analysis` loop with a `rotation_checked` / `apply_rotation` guard so decoding/layout logic is not repeatedly evaluated. 
- Change ffmpeg encode preset from `medium` to `fast` when producing the final encoded output.

### Testing
- Ran a small smoke test invoking `run_pullup_analysis` on a short sample video in both `fast` and `slow` modes and verified that processing completed, overlays were rendered, rotation was corrected for a rotated test clip, and an encoded output file was produced (successful). 
- Verified there are no regressions in overlay rendering by observing identical visual output for non-rotated inputs while CPU work per-frame is reduced (manual/perf check succeeded). 
- No automated unit tests were added or changed in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eeed730948323b0b7bea7072e1f26)