### PR TITLE
Cache overlay fonts/geometry and preserve source rotation metadata on encode

### DIFF
--- a/pullup_analysis.py
+++ b/pullup_analysis.py
@@ -2,7 +2,7 @@
 # pullup_analysis.py — SMART FORM_TIP edition with FAST/SLOW path optimization
 # form_tip = optimization advice (doesn't affect score, only helps improve)
 
-import os, cv2, math, numpy as np, subprocess
+import os, cv2, math, numpy as np, subprocess, re
 from collections import deque
 from PIL import ImageFont, ImageDraw, Image
 
@@ -16,12 +16,62 @@ _REF_FEEDBACK_FONT_SIZE = 22
 _REF_DEPTH_LABEL_FONT_SIZE = 14
 _REF_DEPTH_PCT_FONT_SIZE = 18
 
+# Cache overlay resources per output frame size to avoid expensive per-frame
+# font loading and constant geometry recalculation.
+_OVERLAY_CACHE = {}
+
 def _load_font(p,s):
     try: return ImageFont.truetype(p,s)
     except: return ImageFont.load_default()
 
 def _scaled_font_size(ref_size, canvas_h):
     return max(10, int(round(ref_size * (canvas_h / _REF_H))))
+
+def _get_overlay_cache(w, h):
+    key = (int(w), int(h))
+    cached = _OVERLAY_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    HD_H = 1080
+    hd_scale = HD_H / float(h)
+    HD_W = max(1, int(round(w * hd_scale)))
+
+    reps_font_size = _scaled_font_size(_REF_REPS_FONT_SIZE, HD_H)
+    feedback_font_size = _scaled_font_size(_REF_FEEDBACK_FONT_SIZE, HD_H)
+    depth_label_font_size = _scaled_font_size(_REF_DEPTH_LABEL_FONT_SIZE, HD_H)
+    depth_pct_font_size = _scaled_font_size(_REF_DEPTH_PCT_FONT_SIZE, HD_H)
+
+    reps_font = _load_font(FONT_PATH, reps_font_size)
+    feedback_font = _load_font(FONT_PATH, feedback_font_size)
+    depth_label_font = _load_font(FONT_PATH, depth_label_font_size)
+    depth_pct_font = _load_font(FONT_PATH, depth_pct_font_size)
+
+    ref_h = max(int(HD_H * 0.06), int(reps_font_size * 1.6))
+    radius = int(ref_h * DONUT_RADIUS_SCALE)
+    thick = max(3, int(radius * DONUT_THICKNESS_FRAC))
+    margin = int(12 * hd_scale)
+    cx = HD_W - margin - radius
+    cy = max(ref_h + radius // 8, radius + thick // 2 + 2)
+    pad_x, pad_y = int(10 * hd_scale), int(6 * hd_scale)
+
+    cache = {
+        "HD_H": HD_H,
+        "HD_W": HD_W,
+        "hd_scale": hd_scale,
+        "reps_font": reps_font,
+        "feedback_font": feedback_font,
+        "depth_label_font": depth_label_font,
+        "depth_pct_font": depth_pct_font,
+        "radius": radius,
+        "thick": thick,
+        "cx": cx,
+        "cy": cy,
+        "pad_x": pad_x,
+        "pad_y": pad_y,
+    }
+    _OVERLAY_CACHE[key] = cache
+    return cache
 
 # ============ MediaPipe ============
 try:
@@ -44,6 +94,56 @@ else:
 
 def _get_fast_pose():
     return _FAST_POSE
+
+def _read_source_rotation_degrees(video_path):
+    """Read source rotation metadata without rotating pixels (0/90/180/270)."""
+    try:
+        proc = subprocess.run(
+            [
+                "ffprobe", "-v", "error",
+                "-select_streams", "v:0",
+                "-show_entries", "stream_tags=rotate:stream_side_data=rotation",
+                "-of", "default=noprint_wrappers=1:nokey=1",
+                video_path,
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        if proc.returncode != 0 or not proc.stdout:
+            return 0
+
+        for line in proc.stdout.splitlines():
+            m = re.search(r"-?\d+(?:\.\d+)?", line.strip())
+            if not m:
+                continue
+            try:
+                rot = int(round(float(m.group(0)))) % 360
+            except Exception:
+                continue
+            return min((0, 90, 180, 270), key=lambda x: abs(x - rot))
+    except Exception:
+        pass
+
+    # Fallback for environments that ship ffmpeg without ffprobe.
+    try:
+        proc = subprocess.run(
+            ["ffmpeg", "-i", video_path],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        txt = proc.stderr or ""
+        m = re.search(r"rotate\s*:\s*(-?\d+)", txt)
+        if m:
+            rot = int(m.group(1)) % 360
+            return min((0, 90, 180, 270), key=lambda x: abs(x - rot))
+    except Exception:
+        pass
+
+    return 0
 
 # ============ Helpers ============
 def _ang(a,b,c):
@@ -115,33 +215,27 @@ def draw_body_only(frame, lms, color=(255,255,255)):
 
 def draw_overlay(frame, reps=0, feedback=None, height_pct=0.0):
     h, w, _ = frame.shape
-    HD_H = 1080
-    hd_scale = HD_H / float(h)
-    HD_W = max(1, int(round(w * hd_scale)))
-
-    reps_font_size = _scaled_font_size(_REF_REPS_FONT_SIZE, HD_H)
-    feedback_font_size = _scaled_font_size(_REF_FEEDBACK_FONT_SIZE, HD_H)
-    depth_label_font_size = _scaled_font_size(_REF_DEPTH_LABEL_FONT_SIZE, HD_H)
-    depth_pct_font_size = _scaled_font_size(_REF_DEPTH_PCT_FONT_SIZE, HD_H)
-
-    _REPS_FONT = _load_font(FONT_PATH, reps_font_size)
-    _FEEDBACK_FONT = _load_font(FONT_PATH, feedback_font_size)
-    _DEPTH_LABEL_FONT = _load_font(FONT_PATH, depth_label_font_size)
-    _DEPTH_PCT_FONT = _load_font(FONT_PATH, depth_pct_font_size)
+    cache = _get_overlay_cache(w, h)
+    HD_H = cache["HD_H"]
+    HD_W = cache["HD_W"]
+    hd_scale = cache["hd_scale"]
+    _REPS_FONT = cache["reps_font"]
+    _FEEDBACK_FONT = cache["feedback_font"]
+    _DEPTH_LABEL_FONT = cache["depth_label_font"]
+    _DEPTH_PCT_FONT = cache["depth_pct_font"]
 
     pct = float(np.clip(height_pct, 0, 1))
     bg_alpha_val = int(round(255 * BAR_BG_ALPHA))
 
-    ref_h = max(int(HD_H * 0.06), int(reps_font_size * 1.6))
-    radius = int(ref_h * DONUT_RADIUS_SCALE)
-    thick = max(3, int(radius * DONUT_THICKNESS_FRAC))
-    margin = int(12 * hd_scale)
-    cx = HD_W - margin - radius
-    cy = max(ref_h + radius // 8, radius + thick // 2 + 2)
+    radius = cache["radius"]
+    thick = cache["thick"]
+    cx = cache["cx"]
+    cy = cache["cy"]
 
     overlay_np = np.zeros((HD_H, HD_W, 4), dtype=np.uint8)
 
-    pad_x, pad_y = int(10 * hd_scale), int(6 * hd_scale)
+    pad_x = cache["pad_x"]
+    pad_y = cache["pad_y"]
     tmp_pil = Image.new("RGBA", (1, 1))
     tmp_draw = ImageDraw.Draw(tmp_pil)
     txt = f"Reps: {int(reps)}"
@@ -313,6 +407,7 @@ def run_pullup_analysis(video_path,
     cap=cv2.VideoCapture(video_path)
     if not cap.isOpened(): return _ret_err("Could not open video", feedback_path)
 
+
     fps_in=cap.get(cv2.CAP_PROP_FPS) or 25
     effective_fps=max(1.0, fps_in/max(1,effective_frame_skip))
     sec_to_frames=lambda s: max(1,int(s*effective_fps))
@@ -407,7 +502,8 @@ def run_pullup_analysis(video_path,
             
             if burst_cntr > 0:
                 burst_cntr -= 1
-            
+
+
             processed_frame_count += 1
 
             # Resize frame (for both paths, affects pose detection)
@@ -813,9 +909,18 @@ def run_pullup_analysis(video_path,
     if slow_path and os.path.exists(output_path):
         encoded_path=output_path.replace(".mp4","_encoded.mp4")
         try:
-            subprocess.run(["ffmpeg","-y","-i",output_path,"-c:v","libx264","-preset","medium",
-                            "-crf",str(int(encode_crf if encode_crf is not None else 23)),"-movflags","+faststart","-pix_fmt","yuv420p",
-                            encoded_path], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            source_rotation = _read_source_rotation_degrees(video_path)
+            ffmpeg_cmd = [
+                "ffmpeg", "-y", "-i", output_path,
+                "-c:v", "libx264", "-preset", "fast",
+                "-crf", str(int(encode_crf if encode_crf is not None else 23)),
+                "-movflags", "+faststart", "-pix_fmt", "yuv420p",
+            ]
+            # Preserve source orientation metadata exactly as captured/displayed by clients.
+            ffmpeg_cmd += ["-metadata:s:v:0", f"rotate={int(source_rotation)}"]
+            ffmpeg_cmd += [encoded_path]
+
+            subprocess.run(ffmpeg_cmd, check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             final_path=encoded_path if os.path.exists(encoded_path) else output_path
             if os.path.exists(output_path) and os.path.exists(encoded_path):
                 try: os.remove(output_path)


### PR DESCRIPTION
### Motivation

- Avoid expensive per-frame font loading and repeated geometry calculations in `draw_overlay` by caching resources per output size. 
- Preserve the original source/display orientation when re-encoding slow-path output to avoid rotated videos on clients. 

### Description

- Add an `_OVERLAY_CACHE` and `_get_overlay_cache(w,h)` to precompute and reuse fonts, scaling factors, and donut/overlay geometry. 
- Update `draw_overlay` to pull fonts and layout values from the overlay cache instead of allocating them each frame. 
- Add `_read_source_rotation_degrees(video_path)` that extracts rotation metadata using `ffprobe` with an `ffmpeg` fallback and normalizes it to 0/90/180/270. 
- Use the detected rotation in the re-encoding step by appending `-metadata:s:v:0 rotate=<deg>` to the `ffmpeg` command and switch the x264 preset to `fast`. 
- Minor: import `re` for rotation parsing and small whitespace/cleanup changes. 

### Testing

- Ran a module import and smoke test invoking `draw_overlay` on a synthetic frame to verify no per-frame errors and correct RGBA output. (succeeded) 
- Exercised `_read_source_rotation_degrees` against sample files with and without rotation tags to validate `ffprobe` and `ffmpeg` fallback parsing. (succeeded) 
- Performed a slow-path encode flow on a short test clip to verify the `ffmpeg` command runs and produces an encoded file with the `rotate` metadata applied. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eeed730948323b0b7bea7072e1f26)