### PR TITLE
Render overlay at 1080p then downscale for sharp text

### DIFF
--- a/pushup_analysis.py
+++ b/pushup_analysis.py
@@ -100,17 +100,16 @@ def draw_body_only(frame, lms, color=(255,255,255)):
         cv2.circle(frame,(x,y),dot,color,-1,cv2.LINE_AA)
     return frame
 
-# ============ OVERLAY — frame-resolution cache (fast, sharp, no per-frame font load) ============
-_OVERLAY_CACHE = {}
+# ============ OVERLAY — HD 1080p render → downscale to frame ============
+HD_H = 1080
 
-def _get_overlay_cache(w, h):
-    """Build and cache all static overlay layers at the exact frame resolution."""
-    key = (int(w), int(h))
-    cached = _OVERLAY_CACHE.get(key)
-    if cached is not None:
-        return cached
+def draw_overlay(frame, reps=0, feedback=None, depth_pct=0.0):
+    """Render overlay at 1080p then downscale to frame resolution for sharp text."""
+    h, w = frame.shape[:2]
+    fh = HD_H
+    fw = max(1, int(round(w * fh / h)))
+    pct = float(np.clip(depth_pct, 0, 1))
 
-    fw, fh = int(w), int(h)
     reps_font_size        = _scaled_font_size(_REF_REPS_FONT_SIZE, fh)
     feedback_font_size    = _scaled_font_size(_REF_FEEDBACK_FONT_SIZE, fh)
     depth_label_font_size = _scaled_font_size(_REF_DEPTH_LABEL_FONT_SIZE, fh)
@@ -163,43 +162,15 @@ def _get_overlay_cache(w, h):
     label_block_h = depth_label_font.size + label_gap + depth_pct_font.size
     label_by      = cy - label_block_h // 2
 
-    cache = {
-        "fw": fw, "fh": fh,
-        "reps_font": reps_font, "feedback_font": feedback_font,
-        "depth_label_font": depth_label_font, "depth_pct_font": depth_pct_font,
-        "radius": radius, "thick": thick, "cx": cx, "cy": cy,
-        "rep_box_h": rep_box_h,
-        "rep_txt_x": pad_x, "rep_txt_y": pad_y - 1,
-        "fb_pad_x": fb_pad_x, "fb_pad_y": fb_pad_y,
-        "fb_y0": fb_y0, "fb_y1": fb_y1,
-        "line_h": line_h, "line_gap": line_gap,
-        "max_text_w": max_text_w,
-        "label_by": label_by, "label_gap": label_gap,
-        "rep_bg_pil":   Image.fromarray(rep_bg,   mode="RGBA"),
-        "fb_bg_pil":    Image.fromarray(fb_bg,    mode="RGBA"),
-        "donut_bg_pil": Image.fromarray(donut_bg, mode="RGBA"),
-    }
-    _OVERLAY_CACHE[key] = cache
-    return cache
-
-def draw_overlay(frame, reps=0, feedback=None, depth_pct=0.0):
-    """
-    Sharp, fast overlay rendered directly at frame resolution.
-    Fonts and static layers are cached per resolution — zero per-frame font loading.
-    No 1080p upscale; works at whatever resolution the frame is.
-    """
-    h, w, _ = frame.shape
-    c = _get_overlay_cache(w, h)
-    pct = float(np.clip(depth_pct, 0, 1))
-    fw, fh = c["fw"], c["fh"]
-    cx, cy, radius, thick = c["cx"], c["cy"], c["radius"], c["thick"]
+    rep_txt_x = pad_x
+    rep_txt_y = pad_y - 1
 
     # Composite static layers
     canvas = Image.new("RGBA", (fw, fh), (0, 0, 0, 0))
-    canvas.alpha_composite(c["rep_bg_pil"])
+    canvas.alpha_composite(Image.fromarray(rep_bg, mode="RGBA"))
     if feedback:
-        canvas.alpha_composite(c["fb_bg_pil"])
-    canvas.alpha_composite(c["donut_bg_pil"])
+        canvas.alpha_composite(Image.fromarray(fb_bg, mode="RGBA"))
+    canvas.alpha_composite(Image.fromarray(donut_bg, mode="RGBA"))
 
     # Dynamic arc
     if pct > 0:
@@ -214,33 +185,33 @@ def draw_overlay(frame, reps=0, feedback=None, depth_pct=0.0):
 
     # Reps counter
     txt = f"Reps: {int(reps)}"
-    draw.text((c["rep_txt_x"], c["rep_txt_y"]), txt,
-              font=c["reps_font"], fill=(255, 255, 255, 255))
+    draw.text((rep_txt_x, rep_txt_y), txt,
+              font=reps_font, fill=(255, 255, 255, 255))
 
     # Donut labels
     label   = "DEPTH"
     pct_txt = f"{int(pct * 100)}%"
-    lw = draw.textlength(label,   font=c["depth_label_font"])
-    pw = draw.textlength(pct_txt, font=c["depth_pct_font"])
-    draw.text((cx - int(lw // 2), c["label_by"]),
-              label, font=c["depth_label_font"], fill=(255, 255, 255, 255))
-    draw.text((cx - int(pw // 2), c["label_by"] + c["depth_label_font"].size + c["label_gap"]),
-              pct_txt, font=c["depth_pct_font"], fill=(255, 255, 255, 255))
+    lw = draw.textlength(label,   font=depth_label_font)
+    pw = draw.textlength(pct_txt, font=depth_pct_font)
+    draw.text((cx - int(lw // 2), label_by),
+              label, font=depth_label_font, fill=(255, 255, 255, 255))
+    draw.text((cx - int(pw // 2), label_by + depth_label_font.size + label_gap),
+              pct_txt, font=depth_pct_font, fill=(255, 255, 255, 255))
 
     # Feedback text
     if feedback:
-        fb_lines = _wrap_two_lines(draw, feedback, c["feedback_font"], c["max_text_w"])
-        ty = c["fb_y0"] + c["fb_pad_y"]
+        fb_lines = _wrap_two_lines(draw, feedback, feedback_font, max_text_w)
+        ty = fb_y0 + fb_pad_y
         for ln in fb_lines:
-            tw2 = draw.textlength(ln, font=c["feedback_font"])
-            tx  = max(c["fb_pad_x"], (fw - int(tw2)) // 2)
-            draw.text((tx, ty), ln, font=c["feedback_font"], fill=(255, 255, 255, 255))
-            ty += c["line_h"] + c["line_gap"]
+            tw2 = draw.textlength(ln, font=feedback_font)
+            tx  = max(fb_pad_x, (fw - int(tw2)) // 2)
+            draw.text((tx, ty), ln, font=feedback_font, fill=(255, 255, 255, 255))
+            ty += line_h + line_gap
 
-    # Blend onto frame
-    canvas_np   = np.array(canvas)
-    alpha       = canvas_np[:, :, 3:4].astype(np.float32) / 255.0
-    overlay_bgr = canvas_np[:, :, [2, 1, 0]].astype(np.float32)
+    # Downscale to frame size and alpha blend
+    canvas_small = cv2.resize(np.array(canvas), (w, h), interpolation=cv2.INTER_AREA)
+    alpha       = canvas_small[:, :, 3:4].astype(np.float32) / 255.0
+    overlay_bgr = canvas_small[:, :, [2, 1, 0]].astype(np.float32)
     result = frame.astype(np.float32) * (1.0 - alpha) + overlay_bgr * alpha
     return result.astype(np.uint8)
 
@@ -418,6 +389,9 @@ def run_pushup_analysis(video_path,
     cap=cv2.VideoCapture(video_path)
     if not cap.isOpened(): return _ret_err("Could not open video", feedback_path)
 
+    orig_w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    orig_h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+
     fps_in=cap.get(cv2.CAP_PROP_FPS) or 25
     effective_fps=max(1.0, fps_in/max(1, BASE_FRAME_SKIP))
     sec_to_frames=lambda s: max(1,int(s*effective_fps))
@@ -477,9 +451,6 @@ def run_pushup_analysis(video_path,
 
     burst_cntr=0
 
-    # Output writer dimensions — determined on first processed frame
-    out_w = out_h = None
-
     with mp_pose.Pose(model_complexity=model_complexity, min_detection_confidence=0.5, min_tracking_confidence=0.5) as pose:
         while True:
             ret, frame = cap.read()
@@ -501,10 +472,8 @@ def run_pushup_analysis(video_path,
                 frame=cv2.resize(frame,(0,0),fx=scale,fy=scale)
             h,w=frame.shape[:2]
 
-            # Writer opened at scaled frame resolution — overlay stays sharp with no upscale
             if return_video and out is None:
-                out_w, out_h = w, h
-                out=cv2.VideoWriter(output_path, fourcc, effective_fps, (out_w, out_h))
+                out=cv2.VideoWriter(output_path, fourcc, effective_fps, (orig_w, orig_h))
 
             res=pose.process(cv2.cvtColor(frame,cv2.COLOR_BGR2RGB))
             depth_live=0.0
@@ -513,9 +482,11 @@ def run_pushup_analysis(video_path,
                 nopose_frames_since_any_rep = (nopose_frames_since_any_rep+1) if rep_count>0 else 0
                 if rep_count>0 and nopose_frames_since_any_rep>=NOPOSE_STOP_FRAMES: break
                 if return_video and out is not None:
-                    out.write(draw_overlay(frame, reps=rep_count,
-                                           feedback=(rt_fb_msg if rt_fb_hold>0 else None),
-                                           depth_pct=0.0))
+                    _fo = cv2.resize(frame, (orig_w, orig_h))
+                    _fo = draw_overlay(_fo, reps=rep_count,
+                                       feedback=(rt_fb_msg if rt_fb_hold>0 else None),
+                                       depth_pct=0.0)
+                    out.write(_fo)
                 if rt_fb_hold>0: rt_fb_hold-=1
                 continue
 
@@ -739,13 +710,13 @@ def run_pushup_analysis(video_path,
             else:
                 if rt_fb_hold>0: rt_fb_hold-=1
 
-            # Draw skeleton + overlay directly on the scaled frame — no upscale needed
             if return_video and out is not None:
-                draw_body_only(frame, lms)
-                frame = draw_overlay(frame, reps=rep_count,
-                                     feedback=(rt_fb_msg if rt_fb_hold>0 else None),
-                                     depth_pct=depth_live)
-                out.write(frame)
+                _fo = cv2.resize(frame, (orig_w, orig_h))
+                draw_body_only(_fo, lms)
+                _fo = draw_overlay(_fo, reps=rep_count,
+                                   feedback=(rt_fb_msg if rt_fb_hold>0 else None),
+                                   depth_pct=depth_live)
+                out.write(_fo)
 
             if shoulder_y is not None: shoulder_prev=shoulder_y
 


### PR DESCRIPTION
## Summary
Refactored the overlay rendering system to always render at 1080p resolution and then downscale to the actual frame size. This replaces the previous frame-resolution caching approach and ensures consistently sharp text rendering regardless of input video resolution.

## Key Changes
- **Removed resolution caching**: Eliminated `_OVERLAY_CACHE` dictionary and `_get_overlay_cache()` function that cached overlay components per frame resolution
- **Unified 1080p rendering**: All overlay elements (fonts, backgrounds, text) are now rendered at a fixed 1080p height (`HD_H = 1080`) with proportional width
- **Simplified draw_overlay()**: Moved all overlay construction logic directly into `draw_overlay()` function, eliminating the cache lookup overhead
- **Dynamic downscaling**: Canvas is rendered at 1080p then downscaled to frame resolution using `cv2.INTER_AREA` interpolation before alpha blending
- **Output video handling**: Changed video writer to use original input dimensions (`orig_w`, `orig_h`) instead of scaled frame dimensions
- **Frame resizing for output**: Added explicit resizing of frames to original dimensions before drawing overlay and writing to output video

## Implementation Details
- Original video dimensions are captured at initialization: `orig_w` and `orig_h` from `cv2.VideoCapture`
- Overlay rendering now always targets 1080p height with aspect-ratio-preserving width calculation
- All font sizes and layout calculations are based on the 1080p canvas, then the entire composite is downscaled
- This approach trades per-frame rendering cost for guaranteed text sharpness at any input resolution
- Output video maintains original resolution while internal processing can work at different scales

https://claude.ai/code/session_01M87zVnYy5eUyJAKSF9pvPL