### PR TITLE
Add timeout protection and increase resources for video rendering

### DIFF
--- a/app.py
+++ b/app.py
@@ -372,7 +372,7 @@ def analyze():
                 "detail": "Upload interrupted before the multipart payload was fully received (client/proxy timeout or connection drop)",
                 "content_length": content_length,
                 "size_mb": size_mb,
-                "hint": "Client/proxy timed out during upload. Retry on better network, send smaller/compressed video, or use raw video upload (Content-Type: video/mp4 with ?exercise_type=...&fast=true).",
+                "hint": "Client/proxy timed out during upload. Retry on better network, send smaller/compressed video, or use raw video upload (Content-Type: video/mp4 with ?exercise_type=...&fast=false for analyzed video).",
                 "video_path": ""
             }, 408)
 

--- a/fly.toml
+++ b/fly.toml
@@ -9,13 +9,16 @@ primary_region = "fra"
   force_https = true
   auto_start_machines = true
   auto_stop_machines = "stop"
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ["app"]
+
+  [http_service.http_options]
+    idle_timeout = 600
 
 [vm]
   cpu_kind = "shared"
   cpus = 2
-  memory_mb = 1024
+  memory_mb = 2048
 
 [env]
   PORT = "8080"

--- a/romanian_deadlift_analysis.py
+++ b/romanian_deadlift_analysis.py
@@ -606,13 +606,17 @@ def _analysis_pass(video_path, rotation, frame_skip, scale, fps_in):
 # PASS 2 — video rendering
 # =====================================================================
 def _render_pass(video_path, rotation, frame_skip, output_path, out_w, out_h, fps_in, frame_data):
-    import sys
+    import sys, time
     effective_fps = max(1.0, fps_in / max(1, frame_skip))
     cap = cv2.VideoCapture(video_path)
     fourcc = cv2.VideoWriter_fourcc(*'mp4v')
     out = cv2.VideoWriter(output_path, fourcc, effective_fps, (out_w, out_h))
     frame_idx = written = 0
+    t0 = time.time()
     while cap.isOpened():
+        if time.time() - t0 > 300:
+            print("[RDL] Pass2 timeout", file=sys.stderr, flush=True)
+            break
         ret, frame = cap.read()
         if not ret: break
         frame_idx += 1
@@ -676,7 +680,10 @@ def run_romanian_deadlift_analysis(video_path, frame_skip=3, scale=0.4,
     final_video_path = ""
     if create_video:
         print("[RDL] Pass2 rendering...", file=sys.stderr, flush=True)
-        _render_pass(video_path, rotation, frame_skip, output_path, out_w, out_h, fps_in, frame_data)
+        try:
+            _render_pass(video_path, rotation, frame_skip, output_path, out_w, out_h, fps_in, frame_data)
+        except Exception as e:
+            print(f"[RDL] Pass2 exception: {e}", file=sys.stderr, flush=True)
         encoded = output_path.replace(".mp4", "_encoded.mp4")
         try:
             proc = subprocess.run(


### PR DESCRIPTION
## Summary
This PR adds timeout protection to the video rendering pass and increases server resources to handle longer processing times more reliably.

## Key Changes

- **Video rendering timeout**: Added a 5-minute (300s) timeout in `_render_pass()` to prevent indefinite hangs during video processing, with graceful exit and stderr logging
- **Exception handling**: Wrapped the `_render_pass()` call in try-except to catch and log any exceptions during Pass 2 rendering
- **Server resource allocation**: 
  - Increased VM memory from 1024 MB to 2048 MB to support more intensive video processing
  - Set `min_machines_running = 1` to ensure at least one instance is always available (previously 0)
  - Added 10-minute HTTP idle timeout to accommodate longer-running requests
- **Documentation fix**: Updated error hint message to clarify that `fast=false` should be used for analyzed video output

## Implementation Details

The timeout mechanism uses `time.time()` to track elapsed time since the start of the rendering loop and breaks cleanly if processing exceeds 5 minutes. This prevents the process from consuming resources indefinitely while still allowing legitimate long videos to complete within the timeout window.

The increased memory allocation and minimum machine count improve reliability for production workloads, while the HTTP idle timeout ensures clients don't disconnect prematurely during extended video processing.

https://claude.ai/code/session_017j2bHmBY96ntnVxtmnqf45